### PR TITLE
docs: improve theming section with font customization examples

### DIFF
--- a/.changeset/improve-theming-font-docs.md
+++ b/.changeset/improve-theming-font-docs.md
@@ -1,0 +1,5 @@
+---
+"terminal": patch
+---
+
+Improve theming documentation with detailed font customization examples and additional appearance options. (PR link to be added by maintainer)

--- a/README.md
+++ b/README.md
@@ -120,6 +120,55 @@ Theming is possible. However, there is no user-friendly interface for now.
 3. Notice `terminalOptions` in the text area labeled `Data`. Refer to the [`xterm.js` documentation](https://github.com/xtermjs/xterm.js/blob/master/typings/xterm.d.ts#L26) (`ITerminalOptions`) to set the options. Nested objects may need to be used.
 4. Save the profile. Changes should apply immediately.
 
+#### Common Customizations
+
+##### Font Configuration
+
+To customize the terminal font family and weight, add the following properties to `terminalOptions`:
+
+```json
+"terminalOptions": {
+  "documentOverride": null,
+  "fontFamily": "FiraCode Nerd Font Mono, Consolas, monospace",
+  "fontWeight": "400",
+  "fontWeightBold": "700"
+}
+```
+
+Available font options:
+- `fontFamily`: CSS font-family string with fallback fonts (e.g., `"JetBrains Mono, Courier New, monospace"`)
+- `fontWeight`: Font weight for regular text. Accepts `"normal"`, `"bold"`, or numeric values `"100"`-`"900"` (default: `"400"`)
+- `fontWeightBold`: Font weight for bold text (default: `"700"`)
+- `fontSize`: Font size in pixels (e.g., `14`)
+
+**Note:** After modifying font settings, you may need to restart Obsidian for changes to take effect. For terminals, monospaced fonts are recommended to ensure proper character alignment.
+
+##### Other Appearance Options
+
+Additional `terminalOptions` you can customize (refer to [xterm.js ITerminalOptions](https://xtermjs.org/docs/api/terminal/interfaces/iterminaloptions/) for complete list):
+
+- `cursorBlink`: Enable cursor blinking (`true` or `false`)
+- `cursorStyle`: Cursor style (`"block"`, `"underline"`, or `"bar"`)
+- `theme`: Color theme object with properties like `background`, `foreground`, `cursor`, etc.
+
+Example with multiple customizations:
+
+```json
+"terminalOptions": {
+  "documentOverride": null,
+  "fontFamily": "FiraCode Nerd Font Mono, monospace",
+  "fontSize": 14,
+  "fontWeight": "400",
+  "fontWeightBold": "700",
+  "cursorBlink": true,
+  "cursorStyle": "block",
+  "theme": {
+    "background": "#1e1e1e",
+    "foreground": "#d4d4d4"
+  }
+}
+```
+
 ### Profiles
 
 This plugin comes with several profile presets that you can reference.


### PR DESCRIPTION
## Summary

This PR improves the theming section of the README by adding detailed font customization examples and common appearance options. This makes it much easier for users to customize their terminal's appearance without having to dig through xterm.js documentation.

## Changes

- **Added Font Configuration subsection** with:
  - Step-by-step example showing how to set `fontFamily`, `fontWeight`, and `fontWeightBold`
  - Clear documentation of available font options and their values
  - Note about restart requirement and monospaced font recommendation
  
- **Added Other Appearance Options subsection** with:
  - Common customization options like cursor style and blinking
  - Reference to complete xterm.js ITerminalOptions documentation
  - Comprehensive example showing multiple customizations including theme colors

## Motivation

The current theming section is minimal and requires users to navigate external documentation to understand how to make basic customizations like changing fonts. This improvement provides practical examples that users can directly copy and modify, significantly reducing friction for common customization tasks.

## Testing

- Verified the font configuration works on macOS with FiraCode Nerd Font Mono
- Confirmed that changes apply after Obsidian restart
- Validated JSON syntax in examples

---

Following project conventions:
- Added changeset describing the changes
- Used `patch` semver level for documentation improvements