### PR TITLE
fix(locales): correct mismatched brackets

### DIFF
--- a/.changeset/fix-locales-brackets.md
+++ b/.changeset/fix-locales-brackets.md
@@ -1,0 +1,10 @@
+---
+"@polyipseity/obsidian-terminal": patch
+---
+
+Fix invalid JSON in translation files:
+
+- `assets/locales/zh-Hans/translation.json`
+- `assets/locales/zh-Hant/translation.json`
+
+The entry `components.select-profile.item-text-temporary` contained unmatched brackets, which caused parsing errors and broke localization loading. This patch corrects the brackets so the JSON validates properly.

--- a/assets/locales/zh-Hans/translation.json
+++ b/assets/locales/zh-Hans/translation.json
@@ -71,7 +71,7 @@
 			},
 			"item-text-": "$t(profile-name-formats.long)",
 			"item-text-incompatible": "（$t(generic.incompatible)）$t(components.select-profile.item-text-)",
-			"item-text-temporary": "（$t(generic.temporary)$t(generic.profile）"
+			"item-text-temporary": "（$t(generic.temporary)$t(generic.profile)）"
 		},
 		"terminal": {
 			"display-name": "$t(generic.terminal)：{{name}}",

--- a/assets/locales/zh-Hant/translation.json
+++ b/assets/locales/zh-Hant/translation.json
@@ -71,7 +71,7 @@
 			},
 			"item-text-": "$t(profile-name-formats.long)",
 			"item-text-incompatible": "（$t(generic.incompatible)）$t(components.select-profile.item-text-)",
-			"item-text-temporary": "（$t(generic.temporary)$t(generic.profile）"
+			"item-text-temporary": "（$t(generic.temporary)$t(generic.profile)）"
 		},
 		"terminal": {
 			"display-name": "$t(generic.terminal)：{{name}}",


### PR DESCRIPTION
This PR fixes invalid JSON in the translation files for zh-Hans and zh-Hant.

Problem:
- The entry `components.select-profile.item-text-temporary` had unmatched brackets.
- This caused JSON parse errors and broke localization loading.

Solution:
- Corrected the brackets in both files.
- Verified that the files now parse correctly and translations load as expected.

Impact:
- Users with zh-Hans and zh-Hant locales will no longer encounter broken UI text.
