### PR TITLE
feat: improve default profile UI and ribbon icon UX

### DIFF
--- a/.changeset/clean-tab-title-feature.md
+++ b/.changeset/clean-tab-title-feature.md
@@ -1,0 +1,9 @@
+---
+"obsidian-terminal": minor
+---
+
+Add option to simplify terminal tab titles by displaying only the current
+directory name instead of the full path. When enabled, tab titles extract
+content from parentheses first, then show just the directory basename,
+making titles more readable in narrow tabs.
+([GH#108](https://github.com/polyipseity/obsidian-terminal/pull/108) by [@taisau](https://github.com/taisau))

--- a/.changeset/clean-tab-title-feature.md
+++ b/.changeset/clean-tab-title-feature.md
@@ -1,9 +1,0 @@
----
-"obsidian-terminal": minor
----
-
-Add option to simplify terminal tab titles by displaying only the current
-directory name instead of the full path. When enabled, tab titles extract
-content from parentheses first, then show just the directory basename,
-making titles more readable in narrow tabs.
-([GH#108](https://github.com/polyipseity/obsidian-terminal/pull/108) by [@taisau](https://github.com/taisau))

--- a/.changeset/profile-list-default.md
+++ b/.changeset/profile-list-default.md
@@ -2,8 +2,7 @@
 "obsidian-terminal": minor
 ---
 
-Consolidate default profile selection into the profile list UI. Removed the
-standalone "Default profile" dropdown setting and replaced it with a "Mark as
-default" button in the profile list modal, making it simpler to manage
-default profiles alongside other profile management actions.
-([GH#108](https://github.com/polyipseity/obsidian-terminal/pull/108) by [@taisau](https://github.com/taisau))
+Restore standalone "Default profile" dropdown setting in the settings tab for
+direct profile selection. Provides an alternative to managing default profiles
+through the profile list modal, allowing users to quickly set or clear the
+default profile without opening the profile management dialog.

--- a/.changeset/profile-list-default.md
+++ b/.changeset/profile-list-default.md
@@ -1,0 +1,9 @@
+---
+"obsidian-terminal": minor
+---
+
+Consolidate default profile selection into the profile list UI. Removed the
+standalone "Default profile" dropdown setting and replaced it with a "Mark as
+default" button in the profile list modal, making it simpler to manage
+default profiles alongside other profile management actions.
+([GH#108](https://github.com/polyipseity/obsidian-terminal/pull/108) by [@taisau](https://github.com/taisau))

--- a/.changeset/ribbon-enhanced.md
+++ b/.changeset/ribbon-enhanced.md
@@ -1,0 +1,6 @@
+---
+"obsidian-terminal": minor
+---
+
+Enhance ribbon icon and context menus with default profile and modifier-key support. Ribbon tooltip now displays the default profile name when configured. Holding Ctrl or Meta while clicking the ribbon opens the profile selector instead of the default profile. File and editor context menus now include a direct 'Open in Terminal: Default' option when a default profile exists.
+([GH#108](https://github.com/polyipseity/obsidian-terminal/pull/108) by [@taisau](https://github.com/taisau))

--- a/assets/locales/af/translation.json
+++ b/assets/locales/af/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/am/translation.json
+++ b/assets/locales/am/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/ar/translation.json
+++ b/assets/locales/ar/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/be/translation.json
+++ b/assets/locales/be/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/bg/translation.json
+++ b/assets/locales/bg/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/bn/translation.json
+++ b/assets/locales/bn/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/ca/translation.json
+++ b/assets/locales/ca/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/cs/translation.json
+++ b/assets/locales/cs/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/da/translation.json
+++ b/assets/locales/da/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/de/translation.json
+++ b/assets/locales/de/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/el/translation.json
+++ b/assets/locales/el/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/en/asset.json
+++ b/assets/locales/en/asset.json
@@ -49,7 +49,8 @@
       "type-icon": "type"
     },
     "profile-list": {
-      "edit-icon": "$t(asset:generic.edit-icon)"
+      "edit-icon": "$t(asset:generic.edit-icon)",
+      "mark-as-default-icon": "star"
     },
     "terminal": {
       "edit-modal": {

--- a/assets/locales/en/asset.json
+++ b/assets/locales/en/asset.json
@@ -124,7 +124,6 @@
   "settings": {
     "add-to-command-icon": "$t(asset:generic.terminal-icon)",
     "add-to-context-menu-icon": "menu",
-    "clean-tab-title-icon": "square-check",
     "create-instance-near-existing-ones-icon": "plus",
     "default-profile-icon": "$t(asset:generic.terminal-alt-icon)",
     "documentations": {

--- a/assets/locales/en/asset.json
+++ b/assets/locales/en/asset.json
@@ -49,6 +49,7 @@
       "type-icon": "type"
     },
     "profile-list": {
+      "default-icon": "star",
       "edit-icon": "$t(asset:generic.edit-icon)",
       "mark-as-default-icon": "star"
     },

--- a/assets/locales/en/asset.json
+++ b/assets/locales/en/asset.json
@@ -122,6 +122,7 @@
   "settings": {
     "add-to-command-icon": "$t(asset:generic.terminal-icon)",
     "add-to-context-menu-icon": "menu",
+    "clean-tab-title-icon": "square-check",
     "create-instance-near-existing-ones-icon": "plus",
     "default-profile-icon": "$t(asset:generic.terminal-alt-icon)",
     "documentations": {

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -282,8 +282,6 @@
     "add-to-command": "Add to $t(generic.command)",
     "add-to-context-menu": "Add to $t(generic.context-menu)",
     "advanced": "Advanced",
-    "clean-tab-title": "Simplify $t(generic.terminal) $t(generic.tab) titles",
-    "clean-tab-title-description": "Show only the current directory name in $t(generic.terminal) $t(generic.tab_other), hiding the full path.",
     "create-instance-near-existing-ones": "Create $t(generic.instance) near $t(generic.exist_gerund) ones",
     "create-instance-near-existing-ones-description": "Overrides '$t(settings.new-instance-behavior)' when $t(generic.instance) $t(generic.exist_singular) if $t(generic.true).",
     "default-profile": "Default $t(generic.profile)",

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -279,6 +279,8 @@
     "add-to-command": "Add to $t(generic.command)",
     "add-to-context-menu": "Add to $t(generic.context-menu)",
     "advanced": "Advanced",
+    "clean-tab-title": "Simplify $t(generic.terminal) $t(generic.tab) titles",
+    "clean-tab-title-description": "Show only the current directory name in $t(generic.terminal) $t(generic.tab_other), hiding the full path.",
     "create-instance-near-existing-ones": "Create $t(generic.instance) near $t(generic.exist_gerund) ones",
     "create-instance-near-existing-ones-description": "Overrides '$t(settings.new-instance-behavior)' when $t(generic.instance) $t(generic.exist_singular) if $t(generic.true).",
     "default-profile": "Default $t(generic.profile)",

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default, capitalize)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -231,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -274,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -61,7 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
-      "mark-as-default": "Mark as $t(generic.default, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",

--- a/assets/locales/eo/translation.json
+++ b/assets/locales/eo/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/es/translation.json
+++ b/assets/locales/es/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/eu/translation.json
+++ b/assets/locales/eu/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/fa/translation.json
+++ b/assets/locales/fa/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/fi/translation.json
+++ b/assets/locales/fi/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/fr/translation.json
+++ b/assets/locales/fr/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/gl/translation.json
+++ b/assets/locales/gl/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/he/translation.json
+++ b/assets/locales/he/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/hi/translation.json
+++ b/assets/locales/hi/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/hu/translation.json
+++ b/assets/locales/hu/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/id/translation.json
+++ b/assets/locales/id/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/it/translation.json
+++ b/assets/locales/it/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/ja/translation.json
+++ b/assets/locales/ja/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "作業$t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.terminal)で開く: $t(generic.profile-types.{{type}})"
+    "open-terminal": "$t(generic.terminal)で開く: $t(generic.profile-types.{{type}})",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.terminal)を開く"
+    "open-terminal": "$t(generic.terminal)を開く",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "$t(generic.command)に追加",

--- a/assets/locales/ko/translation.json
+++ b/assets/locales/ko/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "작업 $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.terminal)에서 $t(generic.open): $t(generic.profile-types.{{type}})"
+    "open-terminal": "$t(generic.terminal)에서 $t(generic.open): $t(generic.profile-types.{{type}})",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.terminal) $t(generic.open)"
+    "open-terminal": "$t(generic.terminal) $t(generic.open)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "$t(generic.command)에 추가",

--- a/assets/locales/lv/translation.json
+++ b/assets/locales/lv/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/ml/translation.json
+++ b/assets/locales/ml/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/ms/translation.json
+++ b/assets/locales/ms/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/nl/translation.json
+++ b/assets/locales/nl/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/no/translation.json
+++ b/assets/locales/no/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/oc/translation.json
+++ b/assets/locales/oc/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/pl/translation.json
+++ b/assets/locales/pl/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/pt-BR/translation.json
+++ b/assets/locales/pt-BR/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/pt/translation.json
+++ b/assets/locales/pt/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/ro/translation.json
+++ b/assets/locales/ro/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/ru/translation.json
+++ b/assets/locales/ru/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/se/translation.json
+++ b/assets/locales/se/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/sk/translation.json
+++ b/assets/locales/sk/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/sq/translation.json
+++ b/assets/locales/sq/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/sr/translation.json
+++ b/assets/locales/sr/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/ta/translation.json
+++ b/assets/locales/ta/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/te/translation.json
+++ b/assets/locales/te/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/th/translation.json
+++ b/assets/locales/th/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/tr/translation.json
+++ b/assets/locales/tr/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/uk/translation.json
+++ b/assets/locales/uk/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/ur/translation.json
+++ b/assets/locales/ur/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "($t(generic.incompatible, capitalize)) $t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit, capitalize)",
+      "mark-as-default": "Mark as $t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -230,7 +231,8 @@
     "working-directory": "working $t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)"
+    "open-terminal": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "open-terminal-default": "$t(generic.open, capitalize) in $t(generic.terminal): $t(generic.default)"
   },
   "name": "$t(generic.terminal, capitalize)",
   "notices": {
@@ -273,7 +275,8 @@
     "zshIntegrated": "zsh: $t(generic.profile-types.integrated, capitalize)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)"
+    "open-terminal": "$t(generic.open, capitalize) $t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open, capitalize) $t(generic.terminal): {{name}}"
   },
   "settings": {
     "add-to-command": "Add to $t(generic.command)",

--- a/assets/locales/zh-Hans/translation.json
+++ b/assets/locales/zh-Hans/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "（$t(generic.incompatible)）$t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit)",
+      "mark-as-default": "标记为$t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -214,7 +215,8 @@
     "working-directory": "工作$t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "在$t(generic.terminal)$t(generic.open)：$t(generic.profile-types.{{type}})"
+    "open-terminal": "在$t(generic.terminal)$t(generic.open)：$t(generic.profile-types.{{type}})",
+    "open-terminal-default": "在$t(generic.terminal)$t(generic.open)：$t(generic.default)"
   },
   "name": "$t(generic.terminal)",
   "notices": {
@@ -257,7 +259,8 @@
     "zshIntegrated": "zsh：$t(generic.profile-types.integrated)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open)$t(generic.terminal)"
+    "open-terminal": "$t(generic.open)$t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open)$t(generic.terminal)：{{name}}"
   },
   "settings": {
     "add-to-command": "加入至$t(generic.command)",

--- a/assets/locales/zh-Hant/translation.json
+++ b/assets/locales/zh-Hant/translation.json
@@ -61,6 +61,7 @@
       "descriptor-": "{{info.id}}",
       "descriptor-incompatible": "（$t(generic.incompatible)）$t(components.profile-list.descriptor-)",
       "edit": "$t(generic.edit)",
+      "mark-as-default": "標記為$t(generic.default)",
       "namer-": "{{info.name}}",
       "namer-incompatible": "$t(components.profile-list.namer-)",
       "preset-placeholder": "$t(components.dropdown.placeholder)",
@@ -214,7 +215,8 @@
     "working-directory": "工作$t(generic.directory)"
   },
   "menus": {
-    "open-terminal": "在$t(generic.terminal)$t(generic.open)：$t(generic.profile-types.{{type}})"
+    "open-terminal": "在$t(generic.terminal)$t(generic.open)：$t(generic.profile-types.{{type}})",
+    "open-terminal-default": "在$t(generic.terminal)$t(generic.open)：$t(generic.default)"
   },
   "name": "$t(generic.terminal)",
   "notices": {
@@ -257,7 +259,8 @@
     "zshIntegrated": "zsh：$t(generic.profile-types.integrated)"
   },
   "ribbons": {
-    "open-terminal": "$t(generic.open)$t(generic.terminal)"
+    "open-terminal": "$t(generic.open)$t(generic.terminal)",
+    "open-terminal-default": "$t(generic.open)$t(generic.terminal)：{{name}}"
   },
   "settings": {
     "add-to-command": "加入至$t(generic.command)",

--- a/src/modals.ts
+++ b/src/modals.ts
@@ -1,14 +1,4 @@
 import {
-  CHECK_EXECUTABLE_WAIT,
-  DEFAULT_PYTHONIOENCODING,
-  PYTHON_REQUIREMENTS,
-} from "./magic.js";
-import {
-  DEFAULT_TERMINAL_OPTIONS,
-  PROFILE_PRESETS,
-  PROFILE_PRESET_ORDERED_KEYS,
-} from "./terminal/profile-presets.js";
-import {
   DISABLED_TOOLTIP,
   DOMClasses,
   EditDataModal,
@@ -39,18 +29,28 @@ import {
   useSettings,
   useSubsettings,
 } from "@polyipseity/obsidian-plugin-library";
-import { Modal, type Setting } from "obsidian";
 import { constant, identity, noop } from "lodash-es";
-import { BUNDLE } from "./import.js";
+import { Modal, type Setting } from "obsidian";
 import type { DeepWritable } from "ts-essentials";
+import { BUNDLE } from "./import.js";
+import {
+  CHECK_EXECUTABLE_WAIT,
+  DEFAULT_PYTHONIOENCODING,
+  PYTHON_REQUIREMENTS,
+} from "./magic.js";
+import {
+  DEFAULT_TERMINAL_OPTIONS,
+  PROFILE_PRESETS,
+  PROFILE_PRESET_ORDERED_KEYS,
+} from "./terminal/profile-presets.js";
 import { PROFILE_PROPERTIES } from "./terminal/profile-properties.js";
 import { Pseudoterminal } from "./terminal/pseudoterminal.js";
 
 import SemVer from "semver/classes/semver.js";
-import { Settings } from "./settings-data.js";
-import type { TerminalPlugin } from "./main.js";
-import getPackageVersion from "./get_package_version.py";
 import semverCoerce from "semver/functions/coerce.js";
+import getPackageVersion from "./get_package_version.py";
+import type { TerminalPlugin } from "./main.js";
+import { Settings } from "./settings-data.js";
 
 const childProcess = dynamicRequire<typeof import("node:child_process")>(
     BUNDLE,
@@ -1169,22 +1169,50 @@ export class ProfileModal extends Modal {
 export class ProfileListModal extends ListModal<
   DeepWritable<Settings.Profile>
 > {
-  protected readonly dataKeys;
+  protected readonly dataProfileList: DeepWritable<
+    Omit<ProfileListModal.Data, "entries">
+  >;
+  protected readonly entryKeys;
 
   public constructor(
     context: TerminalPlugin,
-    data: readonly Settings.Profile.Entry[],
+    data: ProfileListModal.Data,
     options?: ProfileListModal.Options,
   ) {
     const { value: i18n } = context.language,
       dataW = cloneAsWritable(data),
-      dataKeys = new Map(dataW.map(([key, value]) => [value, key])),
+      entryKeys = new Map(dataW.entries.map(([key, value]) => [value, key])),
       callback = options?.callback ?? ((): void => {}),
-      keygen = options?.keygen ?? ((): string => self.crypto.randomUUID()),
-      onMarkAsDefault = options?.onMarkAsDefault ?? ((): void => {});
+      keygen = options?.keygen ?? ((): string => self.crypto.randomUUID());
     super(
       context,
       (setting, editable, getter, setter) => {
+        const profileId = entryKeys.get(getter());
+        setting.addButton((button) => {
+          const btn = button
+            .setIcon(
+              i18n.t("asset:components.profile-list.mark-as-default-icon"),
+            )
+            .setTooltip(i18n.t("components.profile-list.mark-as-default"))
+            .onClick(async () => {
+              await setter((item) => {
+                const id = entryKeys.get(item);
+                if (id === void 0) {
+                  return;
+                }
+                if (id === this.dataProfileList.defaultProfile) {
+                  // Unset default profile if it's already the default
+                  this.dataProfileList.defaultProfile = null;
+                  return;
+                }
+                // Set the default profile to the clicked profile
+                this.dataProfileList.defaultProfile = id;
+              });
+            });
+          if (profileId === this.dataProfileList.defaultProfile) {
+            btn.setCta();
+          }
+        });
         setting.addButton((button) =>
           button
             .setIcon(i18n.t("asset:components.profile-list.edit-icon"))
@@ -1199,44 +1227,32 @@ export class ProfileListModal extends ListModal<
             })
             .setDisabled(!editable),
         );
-        setting.addButton((button) =>
-          button
-            .setIcon(
-              i18n.t("asset:components.profile-list.mark-as-default-icon"),
-            )
-            .setTooltip(i18n.t("components.profile-list.mark-as-default"))
-            .onClick(() => {
-              const profileId = dataKeys.get(getter());
-              if (profileId !== void 0) {
-                void onMarkAsDefault(profileId);
-              }
-            }),
-        );
       },
       unexpected,
-      dataW.map(([, value]) => value),
+      dataW.entries.map(([, value]) => value),
       {
         ...options,
         ...({
-          async callback(data0): Promise<void> {
-            await callback(
-              data0.map((profile) => {
-                let id = dataKeys.get(profile);
+          callback: async (data0): Promise<void> => {
+            await callback({
+              ...this.dataProfileList,
+              entries: data0.map((profile) => {
+                let id = entryKeys.get(profile);
                 if (id === void 0) {
-                  dataKeys.set(
+                  entryKeys.set(
                     profile,
-                    (id = randomNotIn([...dataKeys.values()], keygen)),
+                    (id = randomNotIn([...entryKeys.values()], keygen)),
                   );
                 }
                 return [id, cloneAsWritable(profile)];
               }),
-            );
+            });
           },
         } satisfies ProfileListModal.PredefinedOptions),
         descriptor:
           options?.descriptor ??
           ((profile): string => {
-            const id = dataKeys.get(profile) ?? "";
+            const id = entryKeys.get(profile) ?? "";
             return i18n.t(
               `components.profile-list.descriptor-${
                 Settings.Profile.isCompatible(profile, Platform.CURRENT)
@@ -1252,7 +1268,7 @@ export class ProfileListModal extends ListModal<
         namer:
           options?.namer ??
           ((profile): string => {
-            const id = dataKeys.get(profile) ?? "";
+            const id = entryKeys.get(profile) ?? "";
             return i18n.t(
               `components.profile-list.namer-${
                 Settings.Profile.isCompatible(profile, Platform.CURRENT)
@@ -1283,10 +1299,16 @@ export class ProfileListModal extends ListModal<
           ((): string => i18n.t("components.profile-list.title")),
       },
     );
-    this.dataKeys = dataKeys;
+    this.dataProfileList = dataW;
+    this.entryKeys = entryKeys;
   }
 }
 export namespace ProfileListModal {
+  export interface Data {
+    readonly defaultProfile: Settings.DefaultProfile;
+    readonly entries: readonly Settings.Profile.Entry[];
+  }
+
   type InitialOptions = ListModal.Options<DeepWritable<Settings.Profile>>;
   export type PredefinedOptions = {
     readonly [K in "callback"]: InitialOptions[K];
@@ -1295,10 +1317,7 @@ export namespace ProfileListModal {
     InitialOptions,
     keyof PredefinedOptions
   > {
-    readonly callback?: (
-      data: DeepWritable<Settings.Profile.Entry>[],
-    ) => unknown;
+    readonly callback?: (data: DeepWritable<Data>) => unknown;
     readonly keygen?: () => string;
-    readonly onMarkAsDefault?: (profileId: string) => unknown;
   }
 }

--- a/src/modals.ts
+++ b/src/modals.ts
@@ -1180,7 +1180,8 @@ export class ProfileListModal extends ListModal<
       dataW = cloneAsWritable(data),
       dataKeys = new Map(dataW.map(([key, value]) => [value, key])),
       callback = options?.callback ?? ((): void => {}),
-      keygen = options?.keygen ?? ((): string => self.crypto.randomUUID());
+      keygen = options?.keygen ?? ((): string => self.crypto.randomUUID()),
+      onMarkAsDefault = options?.onMarkAsDefault ?? ((): void => {});
     super(
       context,
       (setting, editable, getter, setter) => {
@@ -1197,6 +1198,19 @@ export class ProfileListModal extends ListModal<
               }).open();
             })
             .setDisabled(!editable),
+        );
+        setting.addButton((button) =>
+          button
+            .setIcon(
+              i18n.t("asset:components.profile-list.mark-as-default-icon"),
+            )
+            .setTooltip(i18n.t("components.profile-list.mark-as-default"))
+            .onClick(() => {
+              const profileId = dataKeys.get(getter());
+              if (profileId !== void 0) {
+                void onMarkAsDefault(profileId);
+              }
+            }),
         );
       },
       unexpected,
@@ -1285,5 +1299,6 @@ export namespace ProfileListModal {
       data: DeepWritable<Settings.Profile.Entry>[],
     ) => unknown;
     readonly keygen?: () => string;
+    readonly onMarkAsDefault?: (profileId: string) => unknown;
   }
 }

--- a/src/settings-data.ts
+++ b/src/settings-data.ts
@@ -75,7 +75,6 @@ export interface Settings extends PluginContext.Settings {
   readonly language: Settings.DefaultableLanguage;
   readonly addToCommand: boolean;
   readonly addToContextMenu: boolean;
-  readonly cleanTabTitle: boolean;
   readonly profiles: Settings.Profiles;
   readonly defaultProfile: Settings.DefaultProfile;
 
@@ -113,7 +112,6 @@ export namespace Settings {
   export const DEFAULT: Persistent = deepFreeze({
     addToCommand: true,
     addToContextMenu: true,
-    cleanTabTitle: false,
     createInstanceNearExistingOnes: true,
     errorNoticeTimeout: NOTICE_NO_TIMEOUT,
     exposeInternalModules: true,
@@ -1156,7 +1154,6 @@ export namespace Settings {
       ...PluginContext.Settings.fix(self0).value,
       addToCommand: fixTyped(DEFAULT, unc, "addToCommand", ["boolean"]),
       addToContextMenu: fixTyped(DEFAULT, unc, "addToContextMenu", ["boolean"]),
-      cleanTabTitle: fixTyped(DEFAULT, unc, "cleanTabTitle", ["boolean"]),
       createInstanceNearExistingOnes: fixTyped(
         DEFAULT,
         unc,

--- a/src/settings-data.ts
+++ b/src/settings-data.ts
@@ -75,6 +75,7 @@ export interface Settings extends PluginContext.Settings {
   readonly language: Settings.DefaultableLanguage;
   readonly addToCommand: boolean;
   readonly addToContextMenu: boolean;
+  readonly cleanTabTitle: boolean;
   readonly profiles: Settings.Profiles;
   readonly defaultProfile: Settings.DefaultProfile;
 
@@ -112,6 +113,7 @@ export namespace Settings {
   export const DEFAULT: Persistent = deepFreeze({
     addToCommand: true,
     addToContextMenu: true,
+    cleanTabTitle: false,
     createInstanceNearExistingOnes: true,
     errorNoticeTimeout: NOTICE_NO_TIMEOUT,
     exposeInternalModules: true,
@@ -1154,6 +1156,7 @@ export namespace Settings {
       ...PluginContext.Settings.fix(self0).value,
       addToCommand: fixTyped(DEFAULT, unc, "addToCommand", ["boolean"]),
       addToContextMenu: fixTyped(DEFAULT, unc, "addToContextMenu", ["boolean"]),
+      cleanTabTitle: fixTyped(DEFAULT, unc, "cleanTabTitle", ["boolean"]),
       createInstanceNearExistingOnes: fixTyped(
         DEFAULT,
         unc,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,5 @@
 import {
   AdvancedSettingTab,
-  Platform,
   cloneAsWritable,
   closeSetting,
   createChildElement,
@@ -203,6 +202,13 @@ export class SettingTab extends AdvancedSettingTab<Settings> {
                     },
                     description: (): string =>
                       i18n.t("settings.profile-list.description"),
+                    onMarkAsDefault: async (profileId): Promise<void> => {
+                      await settings.mutate((settingsM) => {
+                        settingsM.defaultProfile =
+                          profileId as Settings.DefaultProfile;
+                      });
+                      this.postMutate();
+                    },
                   },
                 ).open();
               }),
@@ -216,67 +222,6 @@ export class SettingTab extends AdvancedSettingTab<Settings> {
                   settingsM.profiles = cloneAsWritable(
                     Settings.DEFAULT.profiles,
                   );
-                }),
-              () => {
-                this.postMutate();
-              },
-            ),
-          );
-      })
-      .newSetting(containerEl, (setting) => {
-        setting
-          .setName(i18n.t("settings.default-profile"))
-          .setDesc(i18n.t("settings.default-profile-description"))
-          .addDropdown(
-            linkSetting(
-              (): string => settings.value.defaultProfile ?? "",
-              async (value) =>
-                settings.mutate((settingsM) => {
-                  // Unfortunately we have to use the empty string as a sentinel value for "no default profile" because the dropdown component doesn't allow null/undefined values. So we have to coerce it back to null here.
-                  settingsM.defaultProfile =
-                    value === "" ? null : (value as Settings.DefaultProfile);
-                }),
-              () => {
-                this.postMutate();
-              },
-              {
-                pre: (dropdown) => {
-                  dropdown
-                    .addOption("", i18n.t("components.dropdown.placeholder"))
-                    .addOptions(
-                      Object.fromEntries(
-                        Object.entries(settings.value.profiles).map(
-                          ([id, profile]) => [
-                            id,
-                            i18n.t(
-                              `settings.default-profile-name-${
-                                Settings.Profile.isCompatible(
-                                  profile,
-                                  Platform.CURRENT,
-                                )
-                                  ? ""
-                                  : "incompatible"
-                              }`,
-                              {
-                                info: Settings.Profile.info([id, profile]),
-                                interpolation: { escapeValue: false },
-                              },
-                            ),
-                          ],
-                        ),
-                      ),
-                    );
-                },
-              },
-            ),
-          )
-          .addExtraButton(
-            resetButton(
-              i18n.t("asset:settings.default-profile-icon"),
-              i18n.t("settings.reset"),
-              async () =>
-                settings.mutate((settingsM) => {
-                  settingsM.defaultProfile = Settings.DEFAULT.defaultProfile;
                 }),
               () => {
                 this.postMutate();

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -149,6 +149,36 @@ export class SettingTab extends AdvancedSettingTab<Settings> {
       })
       .newSetting(containerEl, (setting) => {
         setting
+          .setName(i18n.t("settings.clean-tab-title"))
+          .setDesc(i18n.t("settings.clean-tab-title-description"))
+          .addToggle(
+            linkSetting(
+              () => settings.value.cleanTabTitle,
+              async (value) =>
+                settings.mutate((settingsM) => {
+                  settingsM.cleanTabTitle = value;
+                }),
+              () => {
+                this.postMutate();
+              },
+            ),
+          )
+          .addExtraButton(
+            resetButton(
+              i18n.t("asset:settings.clean-tab-title-icon"),
+              i18n.t("settings.reset"),
+              async () =>
+                settings.mutate((settingsM) => {
+                  settingsM.cleanTabTitle = Settings.DEFAULT.cleanTabTitle;
+                }),
+              () => {
+                this.postMutate();
+              },
+            ),
+          );
+      })
+      .newSetting(containerEl, (setting) => {
+        setting
           .setName(i18n.t("settings.profiles"))
           .setDesc(
             i18n.t("settings.profiles-description", {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -148,36 +148,6 @@ export class SettingTab extends AdvancedSettingTab<Settings> {
       })
       .newSetting(containerEl, (setting) => {
         setting
-          .setName(i18n.t("settings.clean-tab-title"))
-          .setDesc(i18n.t("settings.clean-tab-title-description"))
-          .addToggle(
-            linkSetting(
-              () => settings.value.cleanTabTitle,
-              async (value) =>
-                settings.mutate((settingsM) => {
-                  settingsM.cleanTabTitle = value;
-                }),
-              () => {
-                this.postMutate();
-              },
-            ),
-          )
-          .addExtraButton(
-            resetButton(
-              i18n.t("asset:settings.clean-tab-title-icon"),
-              i18n.t("settings.reset"),
-              async () =>
-                settings.mutate((settingsM) => {
-                  settingsM.cleanTabTitle = Settings.DEFAULT.cleanTabTitle;
-                }),
-              () => {
-                this.postMutate();
-              },
-            ),
-          );
-      })
-      .newSetting(containerEl, (setting) => {
-        setting
           .setName(i18n.t("settings.profiles"))
           .setDesc(
             i18n.t("settings.profiles-description", {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,6 +6,7 @@ import {
   createDocumentFragment,
   DOMClasses,
   linkSetting,
+  Platform,
   registerSettingsCommands,
   resetButton,
   setTextToEnum,
@@ -189,6 +190,67 @@ export class SettingTab extends AdvancedSettingTab<Settings> {
                   settingsM.profiles = cloneAsWritable(
                     Settings.DEFAULT.profiles,
                   );
+                }),
+              () => {
+                this.postMutate();
+              },
+            ),
+          );
+      })
+      .newSetting(containerEl, (setting) => {
+        setting
+          .setName(i18n.t("settings.default-profile"))
+          .setDesc(i18n.t("settings.default-profile-description"))
+          .addDropdown(
+            linkSetting(
+              (): string => settings.value.defaultProfile ?? "",
+              async (value) =>
+                settings.mutate((settingsM) => {
+                  // Unfortunately we have to use the empty string as a sentinel value for "no default profile" because the dropdown component doesn't allow null/undefined values. So we have to coerce it back to null here.
+                  settingsM.defaultProfile =
+                    value === "" ? null : (value as Settings.DefaultProfile);
+                }),
+              () => {
+                this.postMutate();
+              },
+              {
+                pre: (dropdown) => {
+                  dropdown
+                    .addOption("", i18n.t("components.dropdown.placeholder"))
+                    .addOptions(
+                      Object.fromEntries(
+                        Object.entries(settings.value.profiles).map(
+                          ([id, profile]) => [
+                            id,
+                            i18n.t(
+                              `settings.default-profile-name-${
+                                Settings.Profile.isCompatible(
+                                  profile,
+                                  Platform.CURRENT,
+                                )
+                                  ? ""
+                                  : "incompatible"
+                              }`,
+                              {
+                                info: Settings.Profile.info([id, profile]),
+                                interpolation: { escapeValue: false },
+                              },
+                            ),
+                          ],
+                        ),
+                      ),
+                    );
+                },
+              },
+            ),
+          )
+          .addExtraButton(
+            resetButton(
+              i18n.t("asset:settings.default-profile-icon"),
+              i18n.t("settings.reset"),
+              async () =>
+                settings.mutate((settingsM) => {
+                  settingsM.defaultProfile = Settings.DEFAULT.defaultProfile;
                 }),
               () => {
                 this.postMutate();

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,18 +4,18 @@ import {
   closeSetting,
   createChildElement,
   createDocumentFragment,
+  DOMClasses,
   linkSetting,
   registerSettingsCommands,
   resetButton,
   setTextToEnum,
-  DOMClasses,
 } from "@polyipseity/obsidian-plugin-library";
+import { cloneDeep, size } from "lodash-es";
+import semverLt from "semver/functions/lt.js";
+import type { loadDocumentations } from "./documentations.js";
+import type { TerminalPlugin } from "./main.js";
 import { ProfileListModal, TerminalOptionsModal } from "./modals.js";
 import { Settings } from "./settings-data.js";
-import type { TerminalPlugin } from "./main.js";
-import type { loadDocumentations } from "./documentations.js";
-import semverLt from "semver/functions/lt.js";
-import { cloneDeep, size } from "lodash-es";
 
 export class SettingTab extends AdvancedSettingTab<Settings> {
   public constructor(
@@ -162,23 +162,20 @@ export class SettingTab extends AdvancedSettingTab<Settings> {
               .onClick(() => {
                 new ProfileListModal(
                   context,
-                  Object.entries(settings.value.profiles),
+                  {
+                    defaultProfile: settings.value.defaultProfile,
+                    entries: Object.entries(settings.value.profiles),
+                  },
                   {
                     callback: async (data): Promise<void> => {
                       await settings.mutate((settingsM) => {
-                        settingsM.profiles = Object.fromEntries(data);
+                        settingsM.profiles = Object.fromEntries(data.entries);
+                        settingsM.defaultProfile = data.defaultProfile;
                       });
                       this.postMutate();
                     },
                     description: (): string =>
                       i18n.t("settings.profile-list.description"),
-                    onMarkAsDefault: async (profileId): Promise<void> => {
-                      await settings.mutate((settingsM) => {
-                        settingsM.defaultProfile =
-                          profileId as Settings.DefaultProfile;
-                      });
-                      this.postMutate();
-                    },
                   },
                 ).open();
               }),

--- a/src/terminal/load.ts
+++ b/src/terminal/load.ts
@@ -63,6 +63,28 @@ export function loadTerminal(context: TerminalPlugin): void {
       return ret;
     },
     adapter = vault.adapter instanceof FileSystemAdapter ? vault.adapter : null,
+    defaultContextMenu = (cwd?: TFolder): ((item: MenuItem) => void) | null => {
+      const { defaultProfile, profiles } = settings.value;
+      if (defaultProfile === null || !profiles[defaultProfile]) {
+        return null;
+      }
+      const profile = profiles[defaultProfile];
+      if (!Settings.Profile.isCompatible(profile, Platform.CURRENT)) {
+        return null;
+      }
+      const cwd0 = cwd ? (adapter ? adapter.getFullPath(cwd.path) : null) : cwd;
+      if (cwd0 === null) {
+        return null;
+      }
+      return (item: MenuItem) => {
+        item
+          .setTitle(i18n.t("menus.open-terminal-default"))
+          .setIcon(i18n.t("asset:components.profile-list.default-icon"))
+          .onClick(() => {
+            spawnTerminal(context, profile, { cwd: cwd0 });
+          });
+      };
+    },
     contextMenu = (
       type: Settings.Profile.Type | "select",
       cwd?: TFolder,
@@ -170,8 +192,25 @@ export function loadTerminal(context: TerminalPlugin): void {
     context,
     i18n.t("asset:ribbons.open-terminal-id"),
     i18n.t("asset:ribbons.open-terminal-icon"),
-    () => i18n.t("ribbons.open-terminal"),
-    () => openDefaultProfile(),
+    () => {
+      const { defaultProfile, profiles } = settings.value;
+      const profile =
+        defaultProfile !== null ? profiles[defaultProfile] : undefined;
+      if (profile && Settings.Profile.isCompatible(profile, Platform.CURRENT)) {
+        return i18n.t("ribbons.open-terminal-default", {
+          interpolation: { escapeValue: false },
+          name: Settings.Profile.name(profile),
+        });
+      }
+      return i18n.t("ribbons.open-terminal");
+    },
+    (evt) => {
+      if (evt.metaKey || evt.ctrlKey) {
+        new SelectProfileModal(context, adapter?.getBasePath()).open();
+        return;
+      }
+      openDefaultProfile();
+    },
   );
   context.registerEvent(
     workspace.on("file-menu", (menu, file) => {
@@ -183,6 +222,10 @@ export function loadTerminal(context: TerminalPlugin): void {
         return;
       }
       menu.addSeparator();
+      const defaultItem = defaultContextMenu(folder);
+      if (defaultItem) {
+        menu.addItem(defaultItem);
+      }
       const items = PROFILE_TYPES.map((type) =>
         contextMenu(type, folder),
       ).filter(isNonNil);
@@ -204,6 +247,10 @@ export function loadTerminal(context: TerminalPlugin): void {
       }
       const { parent } = file;
       menu.addSeparator();
+      const defaultItem = defaultContextMenu(parent);
+      if (defaultItem) {
+        menu.addItem(defaultItem);
+      }
       const items = PROFILE_TYPES.map((type) =>
         contextMenu(type, parent),
       ).filter(isNonNil);

--- a/src/terminal/view.ts
+++ b/src/terminal/view.ts
@@ -353,15 +353,9 @@ export class TerminalView extends ItemView {
   protected get name(): string {
     const { context: plugin, state } = this,
       { value: i18n } = plugin.language,
-      { profile } = state;
-    const { name, type } = profile;
+      { profile } = state,
+      { name, type } = profile;
     if (this.title) {
-      if (plugin.settings.value.cleanTabTitle) {
-        // Extract content from parentheses first, then take the last path segment
-        const match = this.title.match(/\(([^)]*)\)/);
-        const content = match ? match[1] : this.title;
-        return content.split(/[\\/]/).pop() || this.title;
-      }
       return this.title;
     }
     if (typeof name === "string" && name) {
@@ -1199,9 +1193,9 @@ export class TerminalView extends ItemView {
           );
           disposer.push(
             settings.onMutate(
-              (s) => s.cleanTabTitle,
-              () => {
-                leaf.updateHeader();
+              (settings0) => settings0.preferredRenderer,
+              (cur) => {
+                renderer.use(cur);
               },
             ),
           );

--- a/src/terminal/view.ts
+++ b/src/terminal/view.ts
@@ -353,9 +353,15 @@ export class TerminalView extends ItemView {
   protected get name(): string {
     const { context: plugin, state } = this,
       { value: i18n } = plugin.language,
-      { profile } = state,
-      { name, type } = profile;
+      { profile } = state;
+    const { name, type } = profile;
     if (this.title) {
+      if (plugin.settings.value.cleanTabTitle) {
+        // Extract content from parentheses first, then take the last path segment
+        const match = this.title.match(/\(([^)]*)\)/);
+        const content = match ? match[1] : this.title;
+        return content.split(/[\\/]/).pop() || this.title;
+      }
       return this.title;
     }
     if (typeof name === "string" && name) {
@@ -1193,9 +1199,9 @@ export class TerminalView extends ItemView {
           );
           disposer.push(
             settings.onMutate(
-              (settings0) => settings0.preferredRenderer,
-              (cur) => {
-                renderer.use(cur);
+              (s) => s.cleanTabTitle,
+              () => {
+                leaf.updateHeader();
               },
             ),
           );


### PR DESCRIPTION
This PR adds a new setting 'Clean Terminal Tab Title' under the Interface section. When enabled, it filters the terminal title to show only the last segment (usually the current directory), making it easier to read in narrow Obsidian tabs.

Changes:
- Added 'cleanTitle' to Settings.
- Added UI toggle in Settings tab.
- Implemented title cleaning logic in TerminalView getter.
- Added reactive update listener for the setting.