### PR TITLE
fix(terminal): enable obsidian:// URI links to be clickable

### DIFF
--- a/.changeset/unicode-hyperlink-regex-minor.md
+++ b/.changeset/unicode-hyperlink-regex-minor.md
@@ -1,0 +1,10 @@
+---
+"obsidian-terminal": minor
+---
+
+Override WebLinksAddon's default regex so `obsidian://` URIs (in addition to
+`https?://`) are recognized as clickable links in the terminal view.
+
+The addon's built-in pattern from v0.12.0 only covered http(s), which meant
+custom-protocol links were ignored. This wider regex keeps existing behavior
+for standard URLs while fixing #88. ([GH#114](https://github.com/polyipseity/obsidian-terminal/pull/114) by [@joe-king-sh](https://github.com/joe-king-sh))

--- a/src/terminal/view.ts
+++ b/src/terminal/view.ts
@@ -1037,8 +1037,13 @@ export class TerminalView extends ItemView {
                 webLinks: new WebLinksAddon(
                   (event, uri) => openExternal(activeSelf(event), uri),
                   {
+                    /*
+                    ref: <https://github.com/xtermjs/xterm.js/blob/fb25eb8f79fd223acef90828dc2990bb7e196a1d/addons/addon-web-links/src/WebLinksAddon.ts#L10-L21>
+
+                    const strictUrlRegex = /(https?|HTTPS?):[/]{2}[^\s"'!*(){}|\\\^<>`]*[^\s"':,.!?{}|\\\^~\[\]`()<>]/;
+                    */
                     urlRegex:
-                      /(https?|HTTPS?|obsidian):[/]{0,2}[^\s"'!*(){}|\\^<>`]*[^\s"':,.!?{}|\\^~[\]`()<>]/,
+                      /(https?|HTTPS?|obsidian|OBSIDIAN):[/]{2}[^\s"'!*(){}|\\^<>`]*[^\s"':,.!?{}|\\^~[\]`()<>]/,
                   },
                 ),
               },


### PR DESCRIPTION
## Summary

- Override the default `urlRegex` in `WebLinksAddon` to match `obsidian://` URIs in addition to `http(s)://`
- The default regex in `@xterm/addon-web-links` v0.12.0 only matches `https?://`, preventing custom protocol links from being clickable in the terminal

Closes #88

## Test plan

- [x] `pnpm run format && pnpm run check && pnpm test` passes
- [x] `pnpm run build:dev` builds successfully
- [x] Manual verification in Obsidian:
  - `echo "obsidian://open?vault=brain&file=test"` — link is clickable
  - `https://` links continue to work as before