### PR TITLE
fix(terminal): fix Shift+Enter newline in TUI apps like Claude Code

### DIFF
--- a/src/terminal/emulator-addons.ts
+++ b/src/terminal/emulator-addons.ts
@@ -677,6 +677,15 @@ export class MacOSOptionKeyPassthroughAddon implements ITerminalAddon {
         return true;
       }
 
+      // Shift+Enter → ESC+CR for TUI apps like Claude Code
+      // This must be handled regardless of passthrough setting
+      if (event.key === "Enter" && event.shiftKey) {
+        if (event.type === "keydown") {
+          terminal.input("\x1b\r");
+        }
+        return false;
+      }
+
       // Only intercept on Mac when passthrough is enabled
       // (macOptionIsMeta is auto-disabled when passthrough is enabled)
       if (!this.isPassthroughEnabled()) {

--- a/src/terminal/emulator.ts
+++ b/src/terminal/emulator.ts
@@ -142,20 +142,6 @@ export class XtermTerminalEmulator<A> {
     const { terminal } = this;
     terminal.open(element);
 
-    terminal.attachCustomKeyEventHandler((event) => {
-      if (event.key === "Enter" && event.shiftKey) {
-        if (event.type === "keydown") {
-          // Send ESC + CR for Shift+Enter, matching what Claude Code
-          // And other TUI apps expect for modified Enter
-          terminal.input("\x1b\r");
-        }
-        // Block both keydown and keypress to prevent xterm
-        // From also sending a plain \r
-        return false;
-      }
-      return true;
-    });
-
     const addons0 = Object.assign(
       {
         fit: new xtermAddonFit.FitAddon(),


### PR DESCRIPTION
## Summary

- Fix Shift+Enter not working as newline in TUI apps (e.g., Claude Code)
- Move Shift+Enter handling into `MacOSOptionKeyPassthroughAddon` to prevent handler overwrite

## Problem

`attachCustomKeyEventHandler` only keeps the last registered handler. The Shift+Enter handler registered in `emulator.ts` was silently overwritten when `MacOSOptionKeyPassthroughAddon.activate()` registered its own handler, causing Shift+Enter to send a plain `\r` (submit) instead of `\x1b\r` (newline).

## Fix

Integrate the Shift+Enter → `ESC+CR` logic into `MacOSOptionKeyPassthroughAddon`'s handler (the one that actually survives), and remove the dead handler from `emulator.ts`.

The Shift+Enter check is placed before the `isPassthroughEnabled()` gate so it works on all platforms, matching the original intent.

Closes #69