### PR TITLE
feat: expose active note path for terminal tools

### DIFF
--- a/src/terminal/load.ts
+++ b/src/terminal/load.ts
@@ -262,4 +262,20 @@ export function loadTerminal(context: TerminalPlugin): void {
       );
     }
   }
+
+  // Track the active note so terminal tools (e.g. Claude Code) can read it
+  if (adapter) {
+    context.registerEvent(
+      workspace.on("active-leaf-change", () => {
+        const file = workspace.getActiveFile();
+        if (file) {
+          vault.adapter
+            .write(".obsidian/active-note.txt", file.path)
+            .catch(() => {
+              /* best-effort */
+            });
+        }
+      }),
+    );
+  }
 }


### PR DESCRIPTION
## Summary

When a user switches to a different note in Obsidian, the plugin now writes the vault-relative path of that note to `.obsidian/active-note.txt`. This lets tools running inside the terminal (AI assistants, neovim, custom scripts) know which file the user is currently looking at without any manual input.

## Motivation

Terminal-based tools have no way to know which note is active in Obsidian. The terminal is a child process with no access to the parent editor's state. This is a common pain point:

- **#76** - "Is it possible to pass current file to terminal?" - Users want to open the active file in terminal editors like neovim
- **#36** - "Pass vault directory path or other variables to the script" - Users want Obsidian context available in the terminal, including the current file
- **#93** - "Feature Request: Set Environment Variables on Terminal Start" - Users want env vars set from Obsidian context

Writing to a file on each `active-leaf-change` event is the simplest approach that works for *running* terminal sessions, not just at spawn time. Environment variables set at spawn time go stale as soon as the user switches files.

## Implementation

- Adds an `active-leaf-change` event listener in `loadTerminal()` (src/terminal/load.ts)
- On each leaf change, calls `workspace.getActiveFile()` and writes the file's vault-relative path to `.obsidian/active-note.txt` via the vault adapter
- Only writes when a file is actually active (skips null)
- Only runs when `FileSystemAdapter` is available (same guard used elsewhere in the function)
- Best-effort: write failures are silently caught to avoid disrupting the user

The change is 12 lines of code. No new dependencies, no settings changes, no UI changes.

## Test plan

- [x] All existing tests pass (14 pytest, 122 vitest)
- [x] Lint and format checks pass
- [x] Manual: open a vault, switch between notes, verify `.obsidian/active-note.txt` updates with the correct vault-relative path
- [x] Manual: verify the file is not written when no note is active (e.g. when the terminal itself is focused, the file retains the last active note path)