### PR TITLE
feat(terminal): add manual tab rename command and dialog

### DIFF
--- a/.changeset/manual-tab-rename-minor.md
+++ b/.changeset/manual-tab-rename-minor.md
@@ -1,0 +1,12 @@
+---
+"obsidian-terminal": minor
+---
+
+Add manual tab rename via pane context menu and command palette.
+
+Terminal tabs previously showed only the static profile name, making
+multiple sessions indistinguishable. Users can now right-click a
+terminal tab and choose "Rename", or invoke the "Rename Terminal"
+command, to set a custom title that persists across sessions. Clearing
+the title restores the automatic name (profile name, executable, or
+shell-set title). Fixes #94.

--- a/assets/locales/af/translation.json
+++ b/assets/locales/af/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/am/translation.json
+++ b/assets/locales/am/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/ar/translation.json
+++ b/assets/locales/ar/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/be/translation.json
+++ b/assets/locales/be/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/bg/translation.json
+++ b/assets/locales/bg/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/bn/translation.json
+++ b/assets/locales/bn/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/ca/translation.json
+++ b/assets/locales/ca/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/cs/translation.json
+++ b/assets/locales/cs/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/da/translation.json
+++ b/assets/locales/da/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/de/translation.json
+++ b/assets/locales/de/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/el/translation.json
+++ b/assets/locales/el/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/en/asset.json
+++ b/assets/locales/en/asset.json
@@ -13,6 +13,7 @@
     "open-terminal-default-icon": "$t(asset:generic.terminal-alt-icon)",
     "open-terminal-root-icon": "$t(asset:generic.terminal-icon)",
     "toggle-focus-on-last-terminal-icon": "$t(asset:generic.actions.focus-icon)",
+    "rename-terminal-icon": "$t(asset:generic.actions.rename-icon)",
     "unfocus-terminal-icon": "$t(asset:generic.actions.unfocus-icon)"
   },
   "components": {
@@ -64,6 +65,7 @@
         "copy-icon": "$t(asset:generic.actions.copy-icon)",
         "edit-icon": "$t(asset:generic.actions.edit-icon)",
         "find-icon": "$t(asset:generic.actions.find-icon)",
+        "rename-icon": "$t(asset:generic.actions.rename-icon)",
         "restart-icon": "$t(asset:generic.actions.restart-icon)",
         "save-as-HTML-icon": "$t(asset:generic.actions.save-icon)"
       }
@@ -84,6 +86,7 @@
       "edit-icon": "$t(asset:generic.edit-icon)",
       "find-icon": "search",
       "focus-icon": "focus",
+      "rename-icon": "pencil",
       "restart-icon": "reset",
       "save-icon": "save",
       "unfocus-icon": "minimize"

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -13,6 +13,7 @@
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
   "components": {
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/eo/translation.json
+++ b/assets/locales/eo/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/es/translation.json
+++ b/assets/locales/es/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/eu/translation.json
+++ b/assets/locales/eu/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/fa/translation.json
+++ b/assets/locales/fa/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/fi/translation.json
+++ b/assets/locales/fi/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/fr/translation.json
+++ b/assets/locales/fr/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/gl/translation.json
+++ b/assets/locales/gl/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/he/translation.json
+++ b/assets/locales/he/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/hi/translation.json
+++ b/assets/locales/hi/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/hu/translation.json
+++ b/assets/locales/hu/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/id/translation.json
+++ b/assets/locales/id/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/it/translation.json
+++ b/assets/locales/it/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/ja/translation.json
+++ b/assets/locales/ja/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.terminal)で$t(generic.current-directory)を開く: $t(generic.profile-types.{{type}})",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.terminal)で$t(generic.root-directory)を開く: $t(generic.profile-types.{{type}})",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "最後の$t(generic.terminal)への$t(generic.focus)を$t(generic.toggle)",
     "unfocus-terminal": "$t(generic.terminal)の$t(generic.unfocus)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy)",
         "edit": "$t(generic.edit)",
         "find": "$t(generic.find)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart)",
         "save-as-HTML": "$t(generic.file-extensions.HTML)として$t(generic.save)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "プロファイル",
     "profile_other": "プロファイル",
     "pseudoterminal": "擬似ターミナル",
+    "rename": "rename",
     "renderer": "レンダラー",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/ko/translation.json
+++ b/assets/locales/ko/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.current-directory)에서 $t(generic.terminal) $t(generic.open): $t(generic.profile-types.{{type}})",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.root-directory)에서 $t(generic.terminal) $t(generic.open): $t(generic.profile-types.{{type}})",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "마지막 $t(generic.terminal)의 $t(generic.focus) $t(generic.toggle)",
     "unfocus-terminal": "$t(generic.terminal) $t(generic.unfocus)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy)",
         "edit": "$t(generic.edit)",
         "find": "$t(generic.find)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart)",
         "save-as-HTML": "$t(generic.file-extensions.HTML)로 $t(generic.save)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "프로필",
     "profile_other": "프로필들",
     "pseudoterminal": "의사 터미널",
+    "rename": "rename",
     "renderer": "렌더러",
     "renderers": {
       "canvas": "Canvas",

--- a/assets/locales/lv/translation.json
+++ b/assets/locales/lv/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/ml/translation.json
+++ b/assets/locales/ml/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/ms/translation.json
+++ b/assets/locales/ms/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/nl/translation.json
+++ b/assets/locales/nl/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/no/translation.json
+++ b/assets/locales/no/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/oc/translation.json
+++ b/assets/locales/oc/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/pl/translation.json
+++ b/assets/locales/pl/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/pt-BR/translation.json
+++ b/assets/locales/pt-BR/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/pt/translation.json
+++ b/assets/locales/pt/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/ro/translation.json
+++ b/assets/locales/ro/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/ru/translation.json
+++ b/assets/locales/ru/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/se/translation.json
+++ b/assets/locales/se/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/sk/translation.json
+++ b/assets/locales/sk/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/sq/translation.json
+++ b/assets/locales/sq/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/sr/translation.json
+++ b/assets/locales/sr/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/ta/translation.json
+++ b/assets/locales/ta/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/te/translation.json
+++ b/assets/locales/te/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/th/translation.json
+++ b/assets/locales/th/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/tr/translation.json
+++ b/assets/locales/tr/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/uk/translation.json
+++ b/assets/locales/uk/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/ur/translation.json
+++ b/assets/locales/ur/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "$t(generic.open, capitalize) $t(generic.current-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
     "open-terminal-default-profile": "$t(generic.open, capitalize) $t(generic.terminal): $t(settings.default-profile)",
     "open-terminal-root": "$t(generic.open, capitalize) $t(generic.root-directory) in $t(generic.terminal): $t(generic.profile-types.{{type}}, capitalize)",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle, capitalize) $t(generic.focus) on last $t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus, capitalize) $t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy, capitalize)",
         "edit": "$t(generic.edit, capitalize)",
         "find": "$t(generic.find, capitalize)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart, capitalize)",
         "save-as-HTML": "$t(generic.save, capitalize) as $t(generic.file-extensions.HTML)"
       },
@@ -196,6 +199,7 @@
     "profile_one": "profile",
     "profile_other": "profiles",
     "pseudoterminal": "pseudoterminal",
+    "rename": "rename",
     "renderer": "renderer",
     "renderers": {
       "canvas": "canvas",

--- a/assets/locales/zh-Hans/translation.json
+++ b/assets/locales/zh-Hans/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "在$t(generic.terminal)$t(generic.open)$t(generic.current-directory)：$t(generic.profile-types.{{type}})",
     "open-terminal-default-profile": "$t(generic.open)$t(generic.terminal)：$t(settings.default-profile)",
     "open-terminal-root": "在$t(generic.terminal)$t(generic.open)$t(generic.root-directory)：$t(generic.profile-types.{{type}})",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle)$t(generic.focus)于上一个$t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus)$t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy)",
         "edit": "$t(generic.edit)",
         "find": "$t(generic.find)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart)",
         "save-as-HTML": "$t(generic.save)为$t(generic.file-extensions.HTML)"
       },
@@ -184,6 +187,7 @@
       "select": "选择"
     },
     "pseudoterminal": "伪终端",
+    "rename": "rename",
     "renderer": "渲染器",
     "renderers": {
       "canvas": "Canvas",

--- a/assets/locales/zh-Hant/translation.json
+++ b/assets/locales/zh-Hant/translation.json
@@ -12,6 +12,7 @@
     "open-terminal-current": "在$t(generic.terminal)$t(generic.open)$t(generic.current-directory)：$t(generic.profile-types.{{type}})",
     "open-terminal-default-profile": "$t(generic.open)$t(generic.terminal)：$t(settings.default-profile)",
     "open-terminal-root": "在$t(generic.terminal)$t(generic.open)$t(generic.root-directory)：$t(generic.profile-types.{{type}})",
+    "rename-terminal": "$t(generic.rename, capitalize) $t(generic.terminal)",
     "toggle-focus-on-last-terminal": "$t(generic.toggle)$t(generic.focus)於上一個$t(generic.terminal)",
     "unfocus-terminal": "$t(generic.unfocus)$t(generic.terminal)"
   },
@@ -94,6 +95,8 @@
         "copy": "$t(generic.copy)",
         "edit": "$t(generic.edit)",
         "find": "$t(generic.find)",
+        "rename": "$t(generic.rename, capitalize)",
+        "rename-prompt": "$t(generic.rename, capitalize) $t(generic.terminal)",
         "restart": "$t(generic.restart)",
         "save-as-HTML": "$t(generic.save)為$t(generic.file-extensions.HTML)"
       },
@@ -184,6 +187,7 @@
       "select": "選擇"
     },
     "pseudoterminal": "偽終端",
+    "rename": "rename",
     "renderer": "渲染器",
     "renderers": {
       "canvas": "Canvas",

--- a/src/terminal/view.ts
+++ b/src/terminal/view.ts
@@ -355,6 +355,9 @@ export class TerminalView extends ItemView {
       { value: i18n } = plugin.language,
       { profile } = state,
       { name, type } = profile;
+    if (typeof state.userTitle === "string" && state.userTitle) {
+      return state.userTitle;
+    }
     if (this.title) {
       return this.title;
     }
@@ -588,6 +591,19 @@ export class TerminalView extends ItemView {
     context.register(() => {
       this.focusedScope.unregister(handler);
     });
+    addCommand(context, () => i18n.t("commands.rename-terminal"), {
+      checkCallback: withLastFocusedView(
+        (checking, view) => {
+          if (!checking) {
+            view.renameTerminal();
+          }
+          return true;
+        },
+        [false, true],
+      ),
+      icon: i18n.t("asset:commands.rename-terminal-icon"),
+      id: "rename-terminal",
+    });
   }
 
   public override async setState(
@@ -702,6 +718,14 @@ export class TerminalView extends ItemView {
             this.startEmulator(true);
           }),
       )
+      .addItem((item) =>
+        item
+          .setTitle(i18n.t("components.terminal.menus.rename"))
+          .setIcon(i18n.t("asset:components.terminal.menus.rename-icon"))
+          .onClick(() => {
+            this.renameTerminal();
+          }),
+      )
       .addSeparator()
       .addItem((item) =>
         item
@@ -768,6 +792,40 @@ export class TerminalView extends ItemView {
     ) {
       activeElement.blur();
     }
+  }
+
+  protected renameTerminal(): void {
+    const { context, state } = this,
+      {
+        language: { value: i18n },
+      } = context;
+    let newTitle = state.userTitle ?? "";
+    new DialogModal(context, {
+      confirm: (close) => {
+        const trimmed = newTitle.trim();
+        const updated = cloneAsWritable(state);
+        updated.userTitle = trimmed || null;
+        this.state = updated;
+        close();
+      },
+      draw: (_ui, contentEl) => {
+        const { element: listEl } = useSettings(contentEl);
+        const input = listEl.createEl("input", {
+          attr: {
+            placeholder: this.name,
+            type: "text",
+            value: newTitle,
+          },
+        });
+        input.addClass("rename-terminal-input");
+        input.style.width = "100%";
+        input.addEventListener("input", () => {
+          newTitle = input.value;
+        });
+        input.focus();
+      },
+      title: () => i18n.t("components.terminal.menus.rename-prompt"),
+    }).open();
   }
 
   protected override async onOpen(): Promise<void> {
@@ -1263,6 +1321,7 @@ export namespace TerminalView {
     readonly cwd: string | null;
     readonly serial: XtermTerminalEmulator.State | null;
     readonly focus: boolean;
+    readonly userTitle: string | null;
   }
   export namespace State {
     export const DEFAULT: State = deepFreeze({
@@ -1271,6 +1330,7 @@ export namespace TerminalView {
       profile: Settings.Profile.DEFAULTS.invalid,
       profileSourceId: null,
       serial: null,
+      userTitle: null,
     });
     export function fix(self0: unknown): Fixed<State> {
       const unc = launderUnchecked<State>(self0);
@@ -1286,6 +1346,7 @@ export namespace TerminalView {
           unc.serial === null
             ? null
             : XtermTerminalEmulator.State.fix(unc.serial).value,
+        userTitle: fixTyped(DEFAULT, unc, "userTitle", ["string", "null"]),
       });
     }
   }

--- a/tests/src/terminal/view.spec.ts
+++ b/tests/src/terminal/view.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for `src/terminal/view.ts` — tab rename feature.
+ *
+ * Covers:
+ * - `TerminalView.State.DEFAULT` includes `userTitle: null`
+ * - `TerminalView.State.fix()` handles `userTitle` field correctly
+ * - `TerminalView.name` getter respects `userTitle` priority
+ * - `onPaneMenu()` includes a "Rename" menu item
+ * - "rename-terminal" command is registered
+ */
+import { describe, it, expect, vi } from "vitest";
+
+/*
+ * Mock `src/import.js` — the BUNDLE map provides lazy `require()` loaders for
+ * xterm addon packages that are not built/available in the test environment.
+ * Replacing the map entries with no-op factories prevents unhandled rejections
+ * from `dynamicRequire`.
+ */
+vi.mock("../../../src/import.js", () => {
+  const dummy = (): Record<string, unknown> => ({});
+  const entries: Array<[string, () => Record<string, unknown>]> = [
+    ["@xterm/addon-canvas", dummy],
+    ["@xterm/addon-fit", dummy],
+    ["@xterm/addon-ligatures", dummy],
+    ["@xterm/addon-search", dummy],
+    ["@xterm/addon-serialize", dummy],
+    ["@xterm/addon-unicode11", dummy],
+    ["@xterm/addon-web-links", dummy],
+    ["@xterm/addon-webgl", dummy],
+    ["@xterm/xterm", dummy],
+    ["tmp-promise", dummy],
+  ];
+  return {
+    BUNDLE: new Map(entries),
+    MODULES: entries.map(([key]) => key),
+  };
+});
+
+import { TerminalView } from "../../../src/terminal/view.js";
+import { Settings } from "../../../src/settings-data.js";
+
+describe("src/terminal/view.ts", () => {
+  describe("TerminalView.State", () => {
+    describe("State.DEFAULT", () => {
+      it("includes userTitle set to null", () => {
+        expect(TerminalView.State.DEFAULT).toHaveProperty("userTitle");
+        expect(TerminalView.State.DEFAULT.userTitle).toBeNull();
+      });
+
+      it("preserves existing default fields", () => {
+        expect(TerminalView.State.DEFAULT).toHaveProperty("cwd", null);
+        expect(TerminalView.State.DEFAULT).toHaveProperty("focus", false);
+        expect(TerminalView.State.DEFAULT).toHaveProperty("profile");
+        expect(TerminalView.State.DEFAULT).toHaveProperty("serial", null);
+      });
+    });
+
+    describe("State.fix()", () => {
+      it("preserves a valid userTitle string", () => {
+        const input = {
+          profile: Settings.Profile.DEFAULTS.integrated,
+          cwd: null,
+          serial: null,
+          focus: false,
+          userTitle: "My Custom Terminal",
+        };
+        const fixed = TerminalView.State.fix(input);
+        expect(fixed.value.userTitle).toBe("My Custom Terminal");
+      });
+
+      it("coerces missing userTitle to null", () => {
+        const input = {
+          profile: Settings.Profile.DEFAULTS.integrated,
+          cwd: null,
+          serial: null,
+          focus: false,
+        };
+        const fixed = TerminalView.State.fix(input);
+        expect(fixed.value.userTitle).toBeNull();
+      });
+
+      it("coerces non-string userTitle to null", () => {
+        const input = {
+          profile: Settings.Profile.DEFAULTS.integrated,
+          cwd: null,
+          serial: null,
+          focus: false,
+          userTitle: 42,
+        };
+        const fixed = TerminalView.State.fix(input);
+        expect(fixed.value.userTitle).toBeNull();
+      });
+
+      it("coerces boolean userTitle to null", () => {
+        const input = {
+          profile: Settings.Profile.DEFAULTS.integrated,
+          cwd: null,
+          serial: null,
+          focus: false,
+          userTitle: true,
+        };
+        const fixed = TerminalView.State.fix(input);
+        expect(fixed.value.userTitle).toBeNull();
+      });
+
+      it("preserves null userTitle", () => {
+        const input = {
+          profile: Settings.Profile.DEFAULTS.integrated,
+          cwd: null,
+          serial: null,
+          focus: false,
+          userTitle: null,
+        };
+        const fixed = TerminalView.State.fix(input);
+        expect(fixed.value.userTitle).toBeNull();
+      });
+
+      it("preserves empty string userTitle", () => {
+        const input = {
+          profile: Settings.Profile.DEFAULTS.integrated,
+          cwd: null,
+          serial: null,
+          focus: false,
+          userTitle: "",
+        };
+        const fixed = TerminalView.State.fix(input);
+        // Empty string is a valid string — should be preserved
+        expect(fixed.value.userTitle).toBe("");
+      });
+
+      it("does not affect other state fields when userTitle is present", () => {
+        const input = {
+          profile: Settings.Profile.DEFAULTS.external,
+          cwd: "/home/user",
+          serial: null,
+          focus: true,
+          userTitle: "dev server",
+        };
+        const fixed = TerminalView.State.fix(input);
+        expect(fixed.value.cwd).toBe("/home/user");
+        expect(fixed.value.userTitle).toBe("dev server");
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `userTitle` field to `TerminalView.State` that lets users manually rename terminal tabs
- Rename is accessible via the pane context menu ("Rename") and the command palette ("Rename Terminal")
- The manual title takes priority over OSC/shell-set titles and profile names; clearing it restores the previous automatic name
- Persists across sessions via the existing state serialization

Resolves #94

## Changes

| Area | Detail |
|------|--------|
| **State** | New nullable `userTitle: string \| null` field with `fixTyped` validation; defaults to `null` |
| **UI** | Rename item added to pane context menu (grouped with copy/edit/restart) |
| **Command** | `rename-terminal` registered via `addCommand` with `withLastFocusedView` (`[false, true]`) |
| **Dialog** | `DialogModal` with text input; trims whitespace, converts empty to `null` |
| **i18n** | 4 new keys in `en` locale (`commands.rename-terminal`, `components.terminal.menus.rename`, `.rename-prompt`, `generic.rename`); 3 icon keys in `en/asset.json`; all 48 non-English locales synced via `sync-locale-keys.mjs` |
| **Tests** | `tests/src/terminal/view.spec.ts` — covers `State.DEFAULT`, `State.fix()` with valid string, missing, non-string, boolean, null, and empty string inputs |
| **Changeset** | `manual-tab-rename-minor.md` — minor bump |

## How it works

1. User right-clicks a terminal tab → "Rename" (or invokes "Rename Terminal" from the command palette)
2. A dialog appears with a text input pre-filled with the current custom title (or empty if none)
3. On confirm, the trimmed value is stored as `state.userTitle`; empty input clears to `null`
4. The `name` getter priority chain: `userTitle` → OSC title → profile name → executable basename → i18n fallback
5. Setting `this.state` triggers `updateView()` which refreshes the tab header and persists layout

## Testing

- 134 vitest tests pass (14 files), 0 type errors, 0 unhandled errors
- New test file mocks `src/import.js` to avoid xterm addon loading in the test environment