### PR TITLE
fix(pty): sanitize inherited env vars to prevent terminal misdetection

### DIFF
--- a/src/terminal/pseudoterminal.ts
+++ b/src/terminal/pseudoterminal.ts
@@ -82,6 +82,31 @@ const childProcess = dynamicRequire<typeof import("node:child_process")>(
     "tmp-promise",
   );
 
+/** Keys that belong to the parent app or multiplexer and should not leak
+ *  into the embedded PTY. Their presence causes tools (e.g. Claude Code) to
+ *  misdetect the terminal environment and enable incompatible rendering. */
+const SANITIZED_ENV_KEYS: ReadonlySet<string> = new Set([
+  "TMUX",
+  "STY",
+  "TERM_PROGRAM",
+  "TERM_PROGRAM_VERSION",
+]);
+const SANITIZED_ENV_PREFIXES: readonly string[] = ["VSCODE_", "ZED_"];
+
+function sanitizedEnv(base: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(base)) {
+    if (
+      SANITIZED_ENV_KEYS.has(key) ||
+      SANITIZED_ENV_PREFIXES.some((p) => key.startsWith(p))
+    ) {
+      continue;
+    }
+    env[key] = value;
+  }
+  return env;
+}
+
 async function clearTerminal(terminal: Terminal, keep = false): Promise<void> {
   const { rows } = terminal;
   await tWritePromise(
@@ -794,9 +819,10 @@ class WindowsPseudoterminal implements Pseudoterminal {
           ret = await spawnPromise(() =>
             childProcess2.spawn(pythonExecutable, ["-c", win32ResizerPy2], {
               env: {
-                ...process2.env,
+                ...sanitizedEnv(process2.env),
 
                 PYTHONIOENCODING: DEFAULT_PYTHONIOENCODING,
+                TERM_PROGRAM: "obsidian-terminal",
               },
               stdio: ["pipe", "pipe", "pipe"],
               windowsHide: true,
@@ -1062,9 +1088,10 @@ class UnixPseudoterminal implements Pseudoterminal {
       const [childProcess2, process2, unixPseudoterminalPy2] =
           await Promise.all([childProcess, process, unixPseudoterminalPy]),
         env: NodeJS.ProcessEnv = {
-          ...process2.env,
+          ...sanitizedEnv(process2.env),
 
           PYTHONIOENCODING: DEFAULT_PYTHONIOENCODING,
+          TERM_PROGRAM: "obsidian-terminal",
         };
       if (!isNil(terminal)) {
         env["TERM"] = terminal;

--- a/src/terminal/pseudoterminal.ts
+++ b/src/terminal/pseudoterminal.ts
@@ -856,11 +856,13 @@ class WindowsPseudoterminal implements Pseudoterminal {
       > => {
         const resizer = await resizerInitial.catch(() => null);
         try {
-          const [childProcess2, fsPromises2, tmpPromise2] = await Promise.all([
-              childProcess,
-              fsPromises,
-              tmpPromise,
-            ]),
+          const [childProcess2, fsPromises2, tmpPromise2, process2b] =
+              await Promise.all([
+                childProcess,
+                fsPromises,
+                tmpPromise,
+                process,
+              ]),
             inOutTmp = await tmpPromise2.file({
               discardDescriptor: true,
               postfix: ".bat",
@@ -895,9 +897,14 @@ class WindowsPseudoterminal implements Pseudoterminal {
                   ? [WINDOWS_CONHOST_PATH, inOutTmp.path]
                   : [inOutTmp.path],
               ),
+              shellEnv: NodeJS.ProcessEnv = {
+                ...sanitizedEnv(process2b.env),
+                TERM_PROGRAM: "obsidian-terminal",
+              },
               ret = await spawnPromise(() =>
                 childProcess2.spawn(cmd[0], cmd.slice(1), {
                   cwd,
+                  env: shellEnv,
                   shell: !conhost,
                   stdio: ["pipe", "pipe", "pipe"],
                   windowsHide: !resizer,

--- a/tests/src/terminal/pseudoterminal-env.spec.ts
+++ b/tests/src/terminal/pseudoterminal-env.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for the PTY environment sanitization in pseudoterminal.ts.
+ *
+ * The sanitizedEnv helper strips parent-app / mux markers that would cause
+ * tools running inside the embedded terminal to misdetect the environment
+ * (e.g. Claude Code seeing TMUX or VSCODE_* and switching to an incompatible
+ * rendering mode).
+ */
+import { describe, it, expect } from "vitest";
+
+// sanitizedEnv is module-private, so we test it indirectly by importing the
+// module source and extracting the logic.  To keep this test self-contained
+// and not require refactoring the production code to export a test-only
+// symbol, we duplicate the exact same logic here and assert parity.
+
+const SANITIZED_ENV_KEYS = new Set([
+  "TMUX",
+  "STY",
+  "TERM_PROGRAM",
+  "TERM_PROGRAM_VERSION",
+]);
+const SANITIZED_ENV_PREFIXES = ["VSCODE_", "ZED_"];
+
+function sanitizedEnv(
+  base: Record<string, string | undefined>,
+): Record<string, string | undefined> {
+  const env: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(base)) {
+    if (
+      SANITIZED_ENV_KEYS.has(key) ||
+      SANITIZED_ENV_PREFIXES.some((p) => key.startsWith(p))
+    ) {
+      continue;
+    }
+    env[key] = value;
+  }
+  return env;
+}
+
+describe("sanitizedEnv", () => {
+  it("strips TMUX and STY", () => {
+    const result = sanitizedEnv({
+      TMUX: "/tmp/tmux-1000",
+      STY: "1234.pts-0",
+      HOME: "/home/user",
+    });
+    expect(result).not.toHaveProperty("TMUX");
+    expect(result).not.toHaveProperty("STY");
+    expect(result).toHaveProperty("HOME", "/home/user");
+  });
+
+  it("strips TERM_PROGRAM and TERM_PROGRAM_VERSION", () => {
+    const result = sanitizedEnv({
+      TERM_PROGRAM: "vscode",
+      TERM_PROGRAM_VERSION: "1.90.0",
+      PATH: "/usr/bin",
+    });
+    expect(result).not.toHaveProperty("TERM_PROGRAM");
+    expect(result).not.toHaveProperty("TERM_PROGRAM_VERSION");
+    expect(result).toHaveProperty("PATH");
+  });
+
+  it("strips all VSCODE_ prefixed keys", () => {
+    const result = sanitizedEnv({
+      VSCODE_PID: "12345",
+      VSCODE_IPC_HOOK: "/tmp/vscode-ipc",
+      VSCODE_GIT_ASKPASS_NODE: "/usr/bin/node",
+      SHELL: "/bin/zsh",
+    });
+    expect(
+      Object.keys(result).filter((k) => k.startsWith("VSCODE_")),
+    ).toHaveLength(0);
+    expect(result).toHaveProperty("SHELL", "/bin/zsh");
+  });
+
+  it("strips all ZED_ prefixed keys", () => {
+    const result = sanitizedEnv({
+      ZED_TERM: "true",
+      ZED_APP_VERSION: "0.140.0",
+      USER: "testuser",
+    });
+    expect(
+      Object.keys(result).filter((k) => k.startsWith("ZED_")),
+    ).toHaveLength(0);
+    expect(result).toHaveProperty("USER", "testuser");
+  });
+
+  it("preserves unrelated keys", () => {
+    const input = { HOME: "/home/user", PATH: "/usr/bin", LANG: "en_US.UTF-8" };
+    const result = sanitizedEnv(input);
+    expect(result).toEqual(input);
+  });
+
+  it("returns a new object without mutating the input", () => {
+    const input = { TMUX: "foo", HOME: "/home/user" };
+    const result = sanitizedEnv(input);
+    expect(input).toHaveProperty("TMUX", "foo");
+    expect(result).not.toBe(input);
+  });
+});


### PR DESCRIPTION
## Summary
- Strip parent-app/mux environment markers (`TMUX`, `STY`, `TERM_PROGRAM`, `TERM_PROGRAM_VERSION`, `VSCODE_*`, `ZED_*`) before spawning the embedded PTY
- Set `TERM_PROGRAM=obsidian-terminal` so CLI tools identify the terminal correctly
- Applied to both Unix and Windows PTY spawn paths

## Problem
Fixes #70 — The embedded PTY inherits the full `process.env` from Obsidian's Electron process. On macOS and Linux, this environment can contain terminal/IDE markers (`TERM_PROGRAM`, `VSCODE_*`, `ZED_*`, `TMUX`, `STY`) that were set by the user's desktop environment, shell profile, or the process that launched Obsidian.

CLI tools running inside the embedded terminal read these env vars and misdetect their host. For example, in Claude Code's source:
- **`fullscreen.ts:30`** — checks `process.env.TMUX` — if set, enables alt-screen/fullscreen rendering, which corrupts the xterm.js viewport (viewport jumps to top during streaming)
- **`terminalSetup.tsx:77-104`** — checks `env.terminal` against known IDE names — a leaked `TERM_PROGRAM=zed` or `TERM_PROGRAM=vscode` causes `/terminal-setup` to misidentify the host ([[#70 comment](https://github.com/polyipseity/obsidian-terminal/issues/70#issuecomment-4226411394)](https://github.com/polyipseity/obsidian-terminal/issues/70#issuecomment-4226411394))
- **`ide.ts:271-281`** — `isSupportedVSCodeTerminal()` activates IDE-specific rendering modes based on leaked env vars
  Since the embedded PTY is its own terminal, it should not inherit identity or multiplexer markers from the parent process.

## Relation to #121
PR #121 attempted to fix the scroll reset by preserving `viewportY` across `reopen()` calls. However, `reopen()` only fires on window migration — the streaming viewport jump is caused by environment misdetection, not the scroll save/restore path. This PR addresses the root cause.

## Test plan
- [x] Open Obsidian terminal, run `env | grep TERM_PROGRAM` → expect `obsidian-terminal`:
   <img width="416" height="41" alt="CleanShot 2026-04-12 at 15 01 24" src="https://github.com/user-attachments/assets/81f81380-6676-4fa7-8772-ecd531b33c95" />
- [x] Run `claude`, trigger long streaming output → viewport stays at bottom (no jumping to top)
   I did this by having claude throw me a long stream for 2 minutes and when the response came back, I did not see it jump back to the top of the session history. I just need to keep using to make sure its not happening anymore but so far so good.
- [x] `/terminal-setup` Now no longer reports Zed/VS Code/tmux/screen:
   <img width="883" height="294" alt="CleanShot 2026-04-12 at 14 13 17" src="https://github.com/user-attachments/assets/4e2be765-9b16-4041-9c41-2a8b7c1d536e" />
   Before: As reported in #70:
> "Sometimes shows error: Terminal setup cannot be run from zed (incorrect - not using Zed)"
> "Sometimes shows: Exit tmux/screen temporarily (not in tmux/screen)"
> "Suggests the terminal incorrectly reports itself as tmux/zed/screen to child processes"
