### PR TITLE
feat: Add setting to toggle key interception

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ __Terminal is focused__
 
 When a terminal is focused, other keyboard shortcuts \(including Obsidian and plugin hotkeys\) are disabled. Only the following keyboard shortcuts work. Thus you can ignore Obsidian complaining about conflicting keys for the following keyboard shortcuts.
 
+This behavior can be turned off via the `Intercept keys when terminal is focused` setting; when disabled, Obsidian hotkeys keep working while the terminal has focus.
+
 - Clear terminal: `Ctrl`+`Shift`+`K`, `Command`+`Shift`+`K` \(Apple\)
 - Close terminal: `Ctrl`+`Shift`+`W`, `Command`+`Shift`+`W` \(Apple\)
 - Find in terminal: `Ctrl`+`Shift`+`F`, `Command`+`Shift`+`F` \(Apple\)
@@ -166,7 +168,7 @@ The full API is available from [`src/@types/obsidian-terminal.ts`](src/%40types/
 - Is the plugin useful on mobile?
   - Compared to on desktop, it is much less useful. The only use for it for now is opening a developer console on mobile.
 - Why do hotkeys not work?
-  - If the terminal is in focus, all Obsidian hotkeys are disabled so that you can type special characters into the terminal. You can unfocus the terminal by pressing `Ctrl`+`Shift`+`` ` ``, then you can use Obsidian hotkeys again.
+  - If the terminal is in focus, all Obsidian hotkeys are disabled so that you can type special characters into the terminal. You can unfocus the terminal by pressing `Ctrl`+`Shift`+`` ` ``, then you can use Obsidian hotkeys again. Alternatively, disable the `Intercept keys when terminal is focused` setting to keep Obsidian hotkeys working while the terminal has focus.
 
 ## Contributing
 

--- a/assets/locales/en/asset.json
+++ b/assets/locales/en/asset.json
@@ -132,6 +132,7 @@
     "expose-internal-modules-icon": "puzzle",
     "focus-on-new-instance-icon": "$t(asset:generic.actions.focus-icon)",
     "hide-status-bar-icon": "eye-off",
+    "intercept-keys-when-focused-icon": "keyboard",
     "intercept-logging-icon": "scroll-text",
     "macOS-option-key-passthrough-icon": "option",
     "new-instance-behavior-icon": "plus",

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -302,6 +302,8 @@
       "running": "When $t(generic.terminal) is running"
     },
     "instancing": "$t(generic.instance_gerund, capitalize)",
+    "intercept-keys-when-focused": "Intercept keys when terminal is focused",
+    "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to terminal-specific commands while the terminal is focused, and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the terminal.",
     "intercept-logging": "Intercept logging",
     "interface": "Interface",
     "macOS-option-key-passthrough": "macOS: Option key passthrough",

--- a/src/settings-data.ts
+++ b/src/settings-data.ts
@@ -90,6 +90,7 @@ export interface Settings extends PluginContext.Settings {
   readonly hideStatusBar: Settings.HideStatusBarOption;
 
   readonly exposeInternalModules: boolean;
+  readonly interceptKeysWhenFocused: boolean;
   readonly interceptLogging: boolean;
   readonly macOSOptionKeyPassthrough: boolean;
   readonly preferredRenderer: Settings.PreferredRendererOption;
@@ -117,6 +118,7 @@ export namespace Settings {
     exposeInternalModules: true,
     focusOnNewInstance: true,
     hideStatusBar: "focused",
+    interceptKeysWhenFocused: true,
     interceptLogging: true,
     language: "",
     macOSOptionKeyPassthrough: true,
@@ -1174,6 +1176,12 @@ export namespace Settings {
         unc,
         "hideStatusBar",
         HIDE_STATUS_BAR_OPTIONS,
+      ),
+      interceptKeysWhenFocused: fixTyped(
+        DEFAULT,
+        unc,
+        "interceptKeysWhenFocused",
+        ["boolean"],
       ),
       interceptLogging: fixTyped(DEFAULT, unc, "interceptLogging", ["boolean"]),
       language: fixInSet(DEFAULT, unc, "language", DEFAULTABLE_LANGUAGES),

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -622,6 +622,37 @@ export class SettingTab extends AdvancedSettingTab<Settings> {
       })
       .newSetting(containerEl, (setting) => {
         setting
+          .setName(i18n.t("settings.intercept-keys-when-focused"))
+          .setDesc(i18n.t("settings.intercept-keys-when-focused-description"))
+          .addToggle(
+            linkSetting(
+              () => settings.value.interceptKeysWhenFocused,
+              async (value) =>
+                settings.mutate((settingsM) => {
+                  settingsM.interceptKeysWhenFocused = value;
+                }),
+              () => {
+                this.postMutate();
+              },
+            ),
+          )
+          .addExtraButton(
+            resetButton(
+              i18n.t("asset:settings.intercept-keys-when-focused-icon"),
+              i18n.t("settings.reset"),
+              async () =>
+                settings.mutate((settingsM) => {
+                  settingsM.interceptKeysWhenFocused =
+                    Settings.DEFAULT.interceptKeysWhenFocused;
+                }),
+              () => {
+                this.postMutate();
+              },
+            ),
+          );
+      })
+      .newSetting(containerEl, (setting) => {
+        setting
           .setName(i18n.t("settings.preferred-renderer"))
           .addDropdown(
             linkSetting(

--- a/src/terminal/view.ts
+++ b/src/terminal/view.ts
@@ -774,7 +774,7 @@ export class TerminalView extends ItemView {
     await super.onOpen();
     const { focusedScope } = TerminalView,
       { context, contentEl, app } = this,
-      { language, statusBarHider } = context,
+      { language, settings, statusBarHider } = context,
       { value: i18n } = language,
       { keymap } = app;
 
@@ -805,15 +805,28 @@ export class TerminalView extends ItemView {
       "focusin",
       () => {
         TerminalView.lastFocusTimes.set(this, Date.now());
-        keymap.pushScope(focusedScope);
+        if (settings.value.interceptKeysWhenFocused) {
+          keymap.pushScope(focusedScope);
+        }
         statusBarHider.update();
       },
       { capture: true, passive: true },
     );
     TerminalView.lastFocusTimes.set(this, Date.now());
-    if (this.isFocused) {
+    if (this.isFocused && settings.value.interceptKeysWhenFocused) {
       keymap.pushScope(focusedScope);
     }
+    this.register(
+      settings.onMutate(
+        (s) => s.interceptKeysWhenFocused,
+        (cur) => {
+          keymap.popScope(focusedScope);
+          if (cur && this.isFocused) {
+            keymap.pushScope(focusedScope);
+          }
+        },
+      ),
+    );
 
     this.register(statusBarHider.hide(() => this.hidesStatusBar));
     this.register(() => {


### PR DESCRIPTION
Added an option to disable key interception to let Obsidian hotkeys work normally while the terminal has focus. Key interception defaults to on.