### PR TITLE
fix: file drop handling

### DIFF
--- a/.changeset/fix-electron-file-drop.md
+++ b/.changeset/fix-electron-file-drop.md
@@ -1,0 +1,5 @@
+---
+"obsidian-terminal": patch
+---
+
+Fix file drop handling by using Electron's webUtils.getPathForFile API with proper error handling. Fixes [GH#113](https://github.com/polyipseity/obsidian-terminal/issues/113). ([GH#152](https://github.com/polyipseity/obsidian-terminal/pull/152) by [@erickpinos](https://github.com/erickpinos))

--- a/src/@types/_electron.d.ts
+++ b/src/@types/_electron.d.ts
@@ -1,0 +1,1 @@
+declare module "electron" {}

--- a/src/@types/electron.ts
+++ b/src/@types/electron.ts
@@ -1,5 +1,70 @@
+declare module "electron" {
+  /**
+   * Electron `webUtils` module for file and media utilities.
+   *
+   * Provides utilities for file handling in the renderer process, including
+   * path resolution for dropped or pasted files.
+   *
+   * Available in Electron 30+. See the Electron documentation for full API details.
+   *
+   * @see https://github.com/electron/electron/blob/main/docs/api/web-utils.md
+   */
+  interface WebUtils {
+    /**
+     * Resolves the file path from a `File` object.
+     *
+     * Electron 32+ removed the `File.path` property. This method provides a
+     * reliable cross-version way to extract file paths from `File` objects,
+     * supporting both older and newer Electron versions.
+     *
+     * @param file - The `File` object to extract the path from (e.g., from
+     *               drag-and-drop, file input, or clipboard paste).
+     * @returns The absolute file path.
+     *
+     * @throws Error if the file path cannot be determined.
+     *
+     * @example
+     * ```ts
+     * import { webUtils } from "electron";
+     * const path = webUtils.getPathForFile(file);
+     * console.log("File path:", path);
+     * ```
+     */
+    getPathForFile(file: File): string;
+  }
+
+  /**
+   * `webUtils` export from the Electron main module.
+   *
+   * Exposed when importing the `"electron"` module in the renderer process via
+   * `require("electron")` or `await import("electron")`.
+   *
+   * `undefined` when running in non-Electron environments or when the module
+   * is unavailable.
+   *
+   * @see WebUtils for available utilities.
+   */
+  const webUtils: WebUtils | undefined;
+}
+
 declare global {
   interface File {
+    /**
+     * Legacy `path` property available on `File` objects in Electron < 32.
+     *
+     * This non-standard property was available in older Electron versions for
+     * accessing file paths from `File` objects in the renderer process. It was
+     * removed in Electron 32 in favor of the standardized `webUtils.getPathForFile()`
+     * API.
+     *
+     * @deprecated Electron 32+: Use `electron.webUtils.getPathForFile(file)` instead.
+     * For older Electron versions (< 30), this property provides a fallback.
+     *
+     * @see https://github.com/electron/electron/blob/main/docs/api/web-utils.md
+     * @see WebUtils.getPathForFile for the recommended replacement.
+     */
     readonly path?: string | undefined;
   }
 }
+
+import type {} from "electron";

--- a/src/terminal/emulator-addons.ts
+++ b/src/terminal/emulator-addons.ts
@@ -37,11 +37,20 @@ export class DragAndDropAddon implements ITerminalAddon {
   public constructor(protected readonly element: HTMLElement) {}
 
   public activate(terminal: Terminal): void {
+    // Electron 32+ removed `File.path`. Use `webUtils.getPathForFile()` and
+    // fall back to the legacy property for older builds.
+    const electron = (globalThis as { require?: (id: string) => unknown })
+      .require?.("electron") as
+      | { webUtils?: { getPathForFile?: (f: File) => string } }
+      | undefined;
+    const getFilePath = (file: File): string | undefined =>
+      electron?.webUtils?.getPathForFile?.(file) ??
+      (file as File & { path?: string }).path;
     const { element } = this,
       drop = (event: DragEvent): void => {
         terminal.paste(
           Array.from(event.dataTransfer?.files ?? [])
-            .map((file) => file.path)
+            .map(getFilePath)
             .filter(isNonNil)
             .map((path) => path.replace(replaceAllRegex('"'), '\\"'))
             .map((path) => (path.includes(" ") ? `"${path}"` : path))

--- a/src/terminal/emulator-addons.ts
+++ b/src/terminal/emulator-addons.ts
@@ -4,6 +4,7 @@ import {
   activeSelf,
   consumeEvent,
   deepFreeze,
+  dynamicRequire,
   isNonNil,
   replaceAllRegex,
   revealPrivate,
@@ -15,6 +16,9 @@ import { constant, isUndefined } from "lodash-es";
 import { around } from "monkey-around";
 import { noop } from "ts-essentials";
 import type { Settings } from "../settings-data.js";
+import { BUNDLE } from "../import.js";
+
+const electron = dynamicRequire<typeof import("electron")>(BUNDLE, "electron");
 
 export class DisposerAddon extends Functions implements ITerminalAddon {
   public constructor(...args: readonly (() => void)[]) {
@@ -37,17 +41,49 @@ export class DragAndDropAddon implements ITerminalAddon {
   public constructor(protected readonly element: HTMLElement) {}
 
   public activate(terminal: Terminal): void {
-    // Electron 32+ removed `File.path`. Use `webUtils.getPathForFile()` and
-    // fall back to the legacy property for older builds.
-    const electron = (globalThis as { require?: (id: string) => unknown })
-      .require?.("electron") as
-      | { webUtils?: { getPathForFile?: (f: File) => string } }
-      | undefined;
-    const getFilePath = (file: File): string | undefined =>
-      electron?.webUtils?.getPathForFile?.(file) ??
-      (file as File & { path?: string }).path;
-    const { element } = this,
-      drop = (event: DragEvent): void => {
+    const { element } = this;
+
+    // Asynchronously load Electron's webUtils API for file path resolution.
+    // This is available in Electron 30+. We load it asynchronously to:
+    // 1. Avoid blocking the terminal initialization
+    // 2. Gracefully handle cases where Electron is unavailable (e.g.,
+    //    running in non-Electron environments or sandboxed contexts)
+    (async (): Promise<void> => {
+      let electron2 = null;
+      try {
+        // Dynamically load the electron module using dynamicRequire with the
+        // configured BUNDLE. This ensures safe loading in both development and
+        // production builds, respecting the plugin's module bundling strategy.
+        electron2 = await electron;
+      } catch (error) {
+        // Electron module failed to load. This is expected in non-Electron
+        // environments. Log at debug level to avoid console spam.
+        // The fallback to File.path will be used if available.
+        /* @__PURE__ */ activeSelf(element).console.debug(error);
+      }
+
+      const getFilePath = (file: File): string | undefined => {
+        // Priority order for file path extraction:
+        // 1. Electron 30+ webUtils.getPathForFile() - recommended, handles edge cases
+        // 2. Catch any errors from getPathForFile() - some paths may fail
+        // 3. Fall back to deprecated File.path - available in Electron < 32
+        if (electron2?.webUtils?.getPathForFile) {
+          try {
+            return electron2.webUtils.getPathForFile(file);
+          } catch (error) {
+            // getPathForFile() failed for this specific file.
+            // This can happen with certain file types or in special contexts.
+            // Log the error and continue with the fallback.
+            /* @__PURE__ */ activeSelf(element).console.warn(error);
+          }
+        }
+        // Fallback to legacy File.path property (Electron < 32).
+        // This property is non-standard and removed in Electron 32+, but provides
+        // compatibility with older versions that may not have webUtils.
+        return file.path;
+      };
+
+      const drop = (event: DragEvent): void => {
         terminal.paste(
           Array.from(event.dataTransfer?.files ?? [])
             .map(getFilePath)
@@ -57,18 +93,27 @@ export class DragAndDropAddon implements ITerminalAddon {
             .join(" "),
         );
         consumeEvent(event);
-      },
-      dragover = consumeEvent;
-    this.#disposer.push(
-      () => {
-        element.removeEventListener("dragover", dragover);
-      },
-      () => {
-        element.removeEventListener("drop", drop);
-      },
-    );
-    element.addEventListener("drop", drop);
-    element.addEventListener("dragover", dragover);
+      };
+
+      // dragover handler - needed to enable the drop target
+      const dragover = consumeEvent;
+
+      // Register event listeners and store cleanup functions.
+      // Both listeners are removed when the addon is disposed to prevent memory leaks.
+      this.#disposer.push(
+        () => {
+          element.removeEventListener("dragover", dragover);
+        },
+        () => {
+          element.removeEventListener("drop", drop);
+        },
+      );
+      element.addEventListener("drop", drop);
+      element.addEventListener("dragover", dragover);
+    })().catch((error) => {
+      // Log errors from the async initialization to help with debugging.
+      activeSelf(element).console.error(error);
+    });
   }
 
   public dispose(): void {


### PR DESCRIPTION
`Cmd+C`/`Cmd+V` clipboard paste behavior works but dragging a file from Finder onto the terminal pane wasn't working.
                                                                                                                                 
### Change                                                                                                                     
- Resolved paths via Electron's `webUtils.getPathForFile(file)`, with a fallback to `file.path`.
                                                                                                                                 
### Tested
- macOS 26.3, Obsidian 1.11.7 → drag image/PDF from Finder → file path pastes at cursor in terminal and in Claude, properly quoted if it contains spaces.

<img width="1065" height="182" alt="Screenshot 2026-05-03 at 4 26 21 PM" src="https://github.com/user-attachments/assets/537d4c77-a9dc-4a39-8077-9728e21d39fe" />