### PR TITLE
fix(documentations): open donation URL when private renderInstalledPlugin fails (#157)

### DIFF
--- a/.changeset/fix-donate-private-api.md
+++ b/.changeset/fix-donate-private-api.md
@@ -1,0 +1,5 @@
+---
+"obsidian-terminal": patch
+---
+
+Fix the donate button and the "open documentation (donate)" command throwing "Error opening documentation" (`TypeError: Cannot read properties of undefined (reading 'addSetting')`) on Obsidian 1.12.7+. Obsidian changed the internal `renderInstalledPlugin` API the plugin relied on to trigger the donation link. `donate()` now falls back to opening the manifest donation URL directly via `openExternal` when the private rendering path is unavailable, so donating works regardless of Obsidian-side private API changes. ([GH#157](https://github.com/polyipseity/obsidian-terminal/issues/157))

--- a/.changeset/fix-donate-private-api.md
+++ b/.changeset/fix-donate-private-api.md
@@ -2,4 +2,4 @@
 "obsidian-terminal": patch
 ---
 
-Fix the donate button and the "open documentation (donate)" command throwing "Error opening documentation" (`TypeError: Cannot read properties of undefined (reading 'addSetting')`) on Obsidian 1.12.7+. Obsidian changed the internal `renderInstalledPlugin` API the plugin relied on to trigger the donation link. `donate()` now falls back to opening the manifest donation URL directly via `openExternal` when the private rendering path is unavailable, so donating works regardless of Obsidian-side private API changes. ([GH#157](https://github.com/polyipseity/obsidian-terminal/issues/157))
+Fix the donate button and "open documentation (donate)" command failing with an error on Obsidian 1.12.7+ due to a private API change. The plugin now finds the donation button directly from the community plugins list and falls back to opening the donation URL when that is not possible. ([GH#157](https://github.com/polyipseity/obsidian-terminal/issues/157) by [@janah01](https://github.com/janah01))

--- a/src/@types/obsidian.ts
+++ b/src/@types/obsidian.ts
@@ -3,6 +3,9 @@ declare module "obsidian" {
   interface App extends Private<$App, PrivateKey> {}
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface SuggestModal<T> extends Private<$SuggestModal, PrivateKey> {}
+  interface PluginManifest {
+    readonly fundingUrl?: string | Record<string, string>;
+  }
 }
 import type {} from "obsidian";
 import type { Private } from "@polyipseity/obsidian-plugin-library";

--- a/src/documentations.ts
+++ b/src/documentations.ts
@@ -1,9 +1,11 @@
 import {
   DocumentationMarkdownView,
   StorageSettingsManager,
+  activeSelf,
   addCommand,
   anyToError,
   deepFreeze,
+  openExternal,
   printError,
   revealPrivate,
   toJSONOrString,
@@ -14,6 +16,15 @@ import type { TerminalPlugin } from "./main.js";
 import changelogMd from "../CHANGELOG.md";
 import readmeMd from "../README.md";
 import semverLt from "semver/functions/lt.js";
+
+export function donationUrls(
+  donationUrl: string | Record<string, string> | undefined,
+): readonly string[] {
+  if (typeof donationUrl === "string") {
+    return [donationUrl];
+  }
+  return donationUrl ? Object.values(donationUrl) : [];
+}
 
 export const DOCUMENTATIONS = deepFreeze({
   async changelog(view: DocumentationMarkdownView.Registered, active: boolean) {
@@ -57,7 +68,11 @@ export const DOCUMENTATIONS = deepFreeze({
         throw new Error(toJSONOrString(settingTabs));
       },
       (error) => {
-        throw error;
+        const [url] = donationUrls(manifest.fundingUrl);
+        if (!url) {
+          throw error;
+        }
+        openExternal(activeSelf(), url);
       },
     );
   },

--- a/src/documentations.ts
+++ b/src/documentations.ts
@@ -17,15 +17,6 @@ import changelogMd from "../CHANGELOG.md";
 import readmeMd from "../README.md";
 import semverLt from "semver/functions/lt.js";
 
-export function donationUrls(
-  donationUrl: string | Record<string, string> | undefined,
-): readonly string[] {
-  if (typeof donationUrl === "string") {
-    return [donationUrl];
-  }
-  return donationUrl ? Object.values(donationUrl) : [];
-}
-
 export const DOCUMENTATIONS = deepFreeze({
   async changelog(view: DocumentationMarkdownView.Registered, active: boolean) {
     await view.open(active, {
@@ -99,8 +90,12 @@ export const DOCUMENTATIONS = deepFreeze({
         throw new Error(toJSONOrString(settingTabs));
       },
       (error) => {
-        const [url] = donationUrls(manifest.fundingUrl);
-        if (!url) {
+        const { fundingUrl } = manifest;
+        const url =
+          typeof fundingUrl === "string"
+            ? fundingUrl
+            : (Object.values(fundingUrl ?? {})[0] ?? null);
+        if (url === null) {
           throw error;
         }
         openExternal(activeSelf(), url);

--- a/src/documentations.ts
+++ b/src/documentations.ts
@@ -48,19 +48,50 @@ export const DOCUMENTATIONS = deepFreeze({
         } = app0;
         for (const tab of settingTabs) {
           const {
-            id,
             containerEl: { ownerDocument },
+            id,
+            installedPlugins,
           } = tab;
           if (id !== "community-plugins") {
             continue;
           }
-          const div = ownerDocument.createElement("div");
-          tab.renderInstalledPlugin(manifest, div);
-          const element = div.querySelector(
-            `.${DOMClasses2.SVG_ICON}.${DOMClasses2.LUCIDE_HEART}`,
-          )?.parentElement;
+
+          // Find the donate button in the already-rendered installed plugins list:
+          // locate this plugin's row by matching the name from the manifest, then
+          // get the heart icon's parent element (the clickable button) and click it.
+          // Note: `textContent` is `string | null` so both `?.` are required;
+          // `querySelector` can also return `null` so `?.parentElement` is needed too.
+          let div = installedPlugins.listEl ?? installedPlugins.containerEl;
+          let element = [
+            ...(div?.querySelectorAll(`.${DOMClasses2.SETTING_ITEM}`) ?? []),
+          ]
+            .find(
+              (item) =>
+                item
+                  .querySelector(`.${DOMClasses2.SETTING_ITEM_NAME}`)
+                  ?.textContent?.trim() === manifest.name,
+            )
+            ?.querySelector(
+              `.${DOMClasses2.SVG_ICON}.${DOMClasses2.LUCIDE_HEART}`,
+            )?.parentElement;
           if (!element) {
-            throw new Error(toJSONOrString(div));
+            activeSelf(ownerDocument).console.warn(toJSONOrString(div));
+
+            // Deprecated: older versions of Obsidian (pre-1.12.7) exposed
+            // `renderInstalledPlugin`, which rendered each plugin's UI into a
+            // caller-supplied detached element; the heart icon was then queried from
+            // that subtree and clicked. This API was removed in Obsidian 1.12.7.
+            div = ownerDocument.createElement("div");
+            tab.renderInstalledPlugin(manifest, div);
+            element = div.querySelector(
+              `.${DOMClasses2.SVG_ICON}.${DOMClasses2.LUCIDE_HEART}`,
+            )?.parentElement;
+            if (!element) {
+              activeSelf(ownerDocument).console.warn(toJSONOrString(div));
+            }
+          }
+          if (!element) {
+            throw new Error(toJSONOrString(tab));
           }
           element.click();
           return;

--- a/src/magic.ts
+++ b/src/magic.ts
@@ -40,6 +40,8 @@ export const CHECK_EXECUTABLE_WAIT = 5,
 
 export namespace DOMClasses2 {
   export const LUCIDE_HEART = "lucide-heart",
+    SETTING_ITEM = "setting-item",
+    SETTING_ITEM_NAME = "setting-item-name",
     SVG_ICON = "svg-icon";
   export namespace Namespaced {
     export const TERMINAL = "terminal";

--- a/tests/src/documentations.spec.ts
+++ b/tests/src/documentations.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for `src/documentations.ts`.
+ *
+ * Covers:
+ * - `donationUrls()` normalizes `manifest.fundingUrl` (string | record | nullish).
+ * - `DOCUMENTATIONS.donate()` falls back to opening the donation URL (and does
+ *   not throw) when the private `renderInstalledPlugin` path fails — regression
+ *   for polyipseity/obsidian-terminal#157 (Obsidian 1.12.7 private API change).
+ *
+ * `revealPrivate` and `openExternal` are external boundaries. `revealPrivate`
+ * is emulated as a `try func / catch -> fallback` wrapper, matching the real
+ * contract evidenced by issue #157's stack trace
+ * (`renderInstalledPlugin -> func -> revealPrivate -> donate`).
+ */
+import { describe, it, expect, vi } from "vitest";
+
+const { openExternalSpy } = vi.hoisted(() => ({
+  openExternalSpy: vi.fn<(win: unknown, url: string) => void>(),
+}));
+
+vi.mock("@polyipseity/obsidian-plugin-library", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@polyipseity/obsidian-plugin-library")
+    >();
+  return {
+    ...actual,
+    openExternal: openExternalSpy,
+    revealPrivate: ((
+      _context: unknown,
+      args: readonly unknown[],
+      func: (...a: readonly unknown[]) => unknown,
+      fallback: (error: unknown) => unknown,
+    ): unknown => {
+      try {
+        return func(...args);
+      } catch (error) {
+        return fallback(error);
+      }
+    }) as unknown as typeof actual.revealPrivate,
+  };
+});
+
+import { donationUrls, DOCUMENTATIONS } from "../../src/documentations.js";
+
+// A donate `view` whose private `renderInstalledPlugin` path always throws,
+// simulating Obsidian 1.12.7's changed private API (issue #157).
+function brokenDonateView(
+  donationUrl: string | Record<string, string> | undefined,
+): Parameters<typeof DOCUMENTATIONS.donate>[0] {
+  const communityPluginsTab = {
+    id: "community-plugins",
+    containerEl: self.document.createElement("div"),
+    renderInstalledPlugin(): void {
+      throw new TypeError(
+        "Cannot read properties of undefined (reading 'addSetting')",
+      );
+    },
+  };
+  return {
+    context: {
+      app: { setting: { settingTabs: [communityPluginsTab] } },
+      manifest: { fundingUrl: donationUrl },
+    },
+  } as unknown as Parameters<typeof DOCUMENTATIONS.donate>[0];
+}
+
+describe("src/documentations.ts", () => {
+  describe("donationUrls()", () => {
+    it("wraps a single string URL", () => {
+      expect(donationUrls("https://buymeacoffee.com/polyipseity")).toEqual([
+        "https://buymeacoffee.com/polyipseity",
+      ]);
+    });
+
+    it("returns the values of a label->url record in order", () => {
+      expect(
+        donationUrls({
+          "Buy Me a Coffee": "https://buymeacoffee.com/polyipseity",
+          "GitHub Sponsors": "https://github.com/sponsors/polyipseity",
+        }),
+      ).toEqual([
+        "https://buymeacoffee.com/polyipseity",
+        "https://github.com/sponsors/polyipseity",
+      ]);
+    });
+
+    it("returns an empty array for undefined", () => {
+      expect(donationUrls(undefined)).toEqual([]);
+    });
+
+    it("returns an empty array for an empty record", () => {
+      expect(donationUrls({})).toEqual([]);
+    });
+
+    // Empty strings pass through; `donate()` guards against them with `!url`.
+    it("preserves an empty string", () => {
+      expect(donationUrls("")).toEqual([""]);
+    });
+  });
+
+  describe("DOCUMENTATIONS.donate()", () => {
+    it("opens the donation URL and does not throw when renderInstalledPlugin fails", () => {
+      openExternalSpy.mockClear();
+
+      expect(() => {
+        DOCUMENTATIONS.donate(
+          brokenDonateView({
+            "Buy Me a Coffee": "https://buymeacoffee.com/polyipseity",
+            "GitHub Sponsors": "https://github.com/sponsors/polyipseity",
+          }),
+        );
+      }).not.toThrow();
+
+      expect(openExternalSpy).toHaveBeenCalledTimes(1);
+      expect(openExternalSpy.mock.calls[0]?.[1]).toBe(
+        "https://buymeacoffee.com/polyipseity",
+      );
+    });
+
+    it("rethrows the original error when there is no usable donation URL", () => {
+      openExternalSpy.mockClear();
+
+      expect(() => {
+        DOCUMENTATIONS.donate(brokenDonateView(""));
+      }).toThrow("addSetting");
+      expect(openExternalSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/src/documentations.spec.ts
+++ b/tests/src/documentations.spec.ts
@@ -3,16 +3,30 @@
  *
  * Covers:
  * - `donationUrls()` normalizes `manifest.fundingUrl` (string | record | nullish).
+ * - `DOCUMENTATIONS.donate()` clicks the heart button when the plugin row is
+ *   found via `installedPlugins.listEl` (primary path, Obsidian 1.12.7+).
+ * - `DOCUMENTATIONS.donate()` clicks the heart button when the plugin row is
+ *   found via `installedPlugins.containerEl` (secondary primary path).
+ * - `DOCUMENTATIONS.donate()` falls back to the deprecated `renderInstalledPlugin`
+ *   path when the primary path finds no matching row (older Obsidian versions).
  * - `DOCUMENTATIONS.donate()` falls back to opening the donation URL (and does
- *   not throw) when the private `renderInstalledPlugin` path fails — regression
- *   for polyipseity/obsidian-terminal#157 (Obsidian 1.12.7 private API change).
+ *   not throw) when both paths fail — regression for polyipseity/obsidian-terminal#157
+ *   (Obsidian 1.12.7 private API change).
+ * - `DOCUMENTATIONS.donate()` warns twice when both the listEl path and the
+ *   deprecated renderInstalledPlugin path find no element, then opens the URL.
  *
  * `revealPrivate` and `openExternal` are external boundaries. `revealPrivate`
  * is emulated as a `try func / catch -> fallback` wrapper, matching the real
  * contract evidenced by issue #157's stack trace
  * (`renderInstalledPlugin -> func -> revealPrivate -> donate`).
+ *
+ * `activeSelf` is stubbed to return `self` unconditionally: the real
+ * implementation accepts `Element | UIEvent | null` but production code
+ * passes a `Document` (from `containerEl.ownerDocument`), which jsdom does
+ * not support — the stub keeps tests hermetic without coupling them to the
+ * activeSelf internals.
  */
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const { openExternalSpy } = vi.hoisted(() => ({
   openExternalSpy: vi.fn<(win: unknown, url: string) => void>(),
@@ -25,6 +39,11 @@ vi.mock("@polyipseity/obsidian-plugin-library", async (importOriginal) => {
     >();
   return {
     ...actual,
+    // Dynamic import is necessary here: this factory runs at module-mock time,
+    // before the test module is loaded, so we must import the original first.
+    // Stub: real activeSelf(Document) crashes in jsdom ("Cannot destructure
+    // property 'defaultView'"); always returning `self` is safe for these tests.
+    activeSelf: (() => self) as unknown as typeof actual.activeSelf,
     openExternal: openExternalSpy,
     revealPrivate: ((
       _context: unknown,
@@ -43,14 +62,45 @@ vi.mock("@polyipseity/obsidian-plugin-library", async (importOriginal) => {
 
 import { donationUrls, DOCUMENTATIONS } from "../../src/documentations.js";
 
-// A donate `view` whose private `renderInstalledPlugin` path always throws,
-// simulating Obsidian 1.12.7's changed private API (issue #157).
+/**
+ * Build a minimal DOM structure matching the installed-plugins list layout:
+ *   .setting-item
+ *     .setting-item-name  (textContent = pluginName)
+ *     button > svg.svg-icon.lucide-heart
+ *
+ * Returns the row element and the clickable heart button so tests can spy on
+ * `click` and assert it was (or was not) invoked.
+ */
+function makePluginRow(pluginName: string): {
+  item: HTMLDivElement;
+  heartButton: HTMLButtonElement;
+} {
+  const item = self.document.createElement("div");
+  item.className = "setting-item";
+  const nameEl = self.document.createElement("div");
+  nameEl.className = "setting-item-name";
+  nameEl.textContent = pluginName;
+  item.appendChild(nameEl);
+  const heartSvg = self.document.createElement("svg");
+  heartSvg.classList.add("svg-icon", "lucide-heart");
+  const heartButton = self.document.createElement("button");
+  heartButton.appendChild(heartSvg);
+  item.appendChild(heartButton);
+  return { item, heartButton };
+}
+
+// A donate `view` whose `installedPlugins.listEl` is empty (no matching row),
+// so donate() falls through to the deprecated `renderInstalledPlugin` path,
+// which always throws — simulating Obsidian 1.12.7's changed private API (#157).
 function brokenDonateView(
   donationUrl: string | Record<string, string> | undefined,
 ): Parameters<typeof DOCUMENTATIONS.donate>[0] {
   const communityPluginsTab = {
     id: "community-plugins",
     containerEl: self.document.createElement("div"),
+    // Empty list: the new installedPlugins.listEl path finds no matching row
+    // and falls through to the deprecated renderInstalledPlugin below.
+    installedPlugins: { listEl: self.document.createElement("ul") },
     renderInstalledPlugin(): void {
       throw new TypeError(
         "Cannot read properties of undefined (reading 'addSetting')",
@@ -68,20 +118,20 @@ function brokenDonateView(
 describe("src/documentations.ts", () => {
   describe("donationUrls()", () => {
     it("wraps a single string URL", () => {
-      expect(donationUrls("https://buymeacoffee.com/polyipseity")).toEqual([
-        "https://buymeacoffee.com/polyipseity",
+      expect(donationUrls("https://example.com/donate")).toEqual([
+        "https://example.com/donate",
       ]);
     });
 
     it("returns the values of a label->url record in order", () => {
       expect(
         donationUrls({
-          "Buy Me a Coffee": "https://buymeacoffee.com/polyipseity",
-          "GitHub Sponsors": "https://github.com/sponsors/polyipseity",
+          "Sponsor A": "https://example.com/donate-a",
+          "Sponsor B": "https://example.com/donate-b",
         }),
       ).toEqual([
-        "https://buymeacoffee.com/polyipseity",
-        "https://github.com/sponsors/polyipseity",
+        "https://example.com/donate-a",
+        "https://example.com/donate-b",
       ]);
     });
 
@@ -100,31 +150,146 @@ describe("src/documentations.ts", () => {
   });
 
   describe("DOCUMENTATIONS.donate()", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("clicks the heart button when the plugin row is found via installedPlugins.listEl", () => {
+      openExternalSpy.mockClear();
+      const warnSpy = vi.spyOn(self.console, "warn");
+
+      const listEl = self.document.createElement("ul");
+      const { item, heartButton } = makePluginRow("Terminal");
+      listEl.appendChild(item);
+      const clickSpy = vi.spyOn(heartButton, "click");
+
+      expect(() => {
+        DOCUMENTATIONS.donate({
+          context: {
+            app: {
+              setting: {
+                settingTabs: [
+                  {
+                    id: "community-plugins",
+                    containerEl: self.document.createElement("div"),
+                    installedPlugins: { listEl },
+                  },
+                ],
+              },
+            },
+            manifest: { name: "Terminal", fundingUrl: {} },
+          },
+        } as unknown as Parameters<typeof DOCUMENTATIONS.donate>[0]);
+      }).not.toThrow();
+
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+      expect(openExternalSpy).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("clicks the heart button when the plugin row is found via installedPlugins.containerEl", () => {
+      openExternalSpy.mockClear();
+      const warnSpy = vi.spyOn(self.console, "warn");
+
+      // installedPlugins.listEl is null so the ?? falls through to containerEl.
+      const pluginsContainerEl = self.document.createElement("div");
+      const { item, heartButton } = makePluginRow("Terminal");
+      pluginsContainerEl.appendChild(item);
+      const clickSpy = vi.spyOn(heartButton, "click");
+
+      expect(() => {
+        DOCUMENTATIONS.donate({
+          context: {
+            app: {
+              setting: {
+                settingTabs: [
+                  {
+                    id: "community-plugins",
+                    containerEl: self.document.createElement("div"),
+                    installedPlugins: {
+                      listEl: null as unknown as HTMLElement,
+                      containerEl: pluginsContainerEl,
+                    },
+                  },
+                ],
+              },
+            },
+            manifest: { name: "Terminal", fundingUrl: {} },
+          },
+        } as unknown as Parameters<typeof DOCUMENTATIONS.donate>[0]);
+      }).not.toThrow();
+
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+      expect(openExternalSpy).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
     it("opens the donation URL and does not throw when renderInstalledPlugin fails", () => {
       openExternalSpy.mockClear();
+      const warnSpy = vi.spyOn(self.console, "warn");
 
       expect(() => {
         DOCUMENTATIONS.donate(
           brokenDonateView({
-            "Buy Me a Coffee": "https://buymeacoffee.com/polyipseity",
-            "GitHub Sponsors": "https://github.com/sponsors/polyipseity",
+            "Sponsor A": "https://example.com/donate-a",
+            "Sponsor B": "https://example.com/donate-b",
           }),
         );
       }).not.toThrow();
 
       expect(openExternalSpy).toHaveBeenCalledTimes(1);
       expect(openExternalSpy.mock.calls[0]?.[1]).toBe(
-        "https://buymeacoffee.com/polyipseity",
+        "https://example.com/donate-a",
       );
+      // The primary listEl path found no element — one warning before the
+      // deprecated fallback was attempted (which then threw).
+      expect(warnSpy).toHaveBeenCalledTimes(1);
     });
 
     it("rethrows the original error when there is no usable donation URL", () => {
       openExternalSpy.mockClear();
+      const warnSpy = vi.spyOn(self.console, "warn");
 
       expect(() => {
         DOCUMENTATIONS.donate(brokenDonateView(""));
       }).toThrow("addSetting");
       expect(openExternalSpy).not.toHaveBeenCalled();
+      // One warning from the primary listEl path before the deprecated fallback
+      // was attempted (which then threw the rethrown error).
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("warns twice and opens the URL when both listEl and renderInstalledPlugin find no element", () => {
+      openExternalSpy.mockClear();
+      const warnSpy = vi.spyOn(self.console, "warn");
+
+      // renderInstalledPlugin renders a node with no heart icon — unlike the
+      // brokenDonateView helper it does not throw, so donate() reaches the
+      // second warning and the inner throw before the revealPrivate fallback.
+      const communityPluginsTab = {
+        id: "community-plugins",
+        containerEl: self.document.createElement("div"),
+        installedPlugins: { listEl: self.document.createElement("ul") },
+        renderInstalledPlugin(_manifest: unknown, div: HTMLElement): void {
+          div.appendChild(self.document.createElement("span"));
+        },
+      };
+
+      expect(() => {
+        DOCUMENTATIONS.donate({
+          context: {
+            app: { setting: { settingTabs: [communityPluginsTab] } },
+            manifest: { fundingUrl: "https://example.com/donate" },
+          },
+        } as unknown as Parameters<typeof DOCUMENTATIONS.donate>[0]);
+      }).not.toThrow();
+
+      // First warn: primary listEl path. Second warn: deprecated path also fails.
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+      expect(openExternalSpy).toHaveBeenCalledTimes(1);
+      expect(openExternalSpy.mock.calls[0]?.[1]).toBe(
+        "https://example.com/donate",
+      );
     });
   });
 });

--- a/tests/src/documentations.spec.ts
+++ b/tests/src/documentations.spec.ts
@@ -2,7 +2,6 @@
  * Unit tests for `src/documentations.ts`.
  *
  * Covers:
- * - `donationUrls()` normalizes `manifest.fundingUrl` (string | record | nullish).
  * - `DOCUMENTATIONS.donate()` clicks the heart button when the plugin row is
  *   found via `installedPlugins.listEl` (primary path, Obsidian 1.12.7+).
  * - `DOCUMENTATIONS.donate()` clicks the heart button when the plugin row is
@@ -60,7 +59,7 @@ vi.mock("@polyipseity/obsidian-plugin-library", async (importOriginal) => {
   };
 });
 
-import { donationUrls, DOCUMENTATIONS } from "../../src/documentations.js";
+import { DOCUMENTATIONS } from "../../src/documentations.js";
 
 /**
  * Build a minimal DOM structure matching the installed-plugins list layout:
@@ -116,39 +115,6 @@ function brokenDonateView(
 }
 
 describe("src/documentations.ts", () => {
-  describe("donationUrls()", () => {
-    it("wraps a single string URL", () => {
-      expect(donationUrls("https://example.com/donate")).toEqual([
-        "https://example.com/donate",
-      ]);
-    });
-
-    it("returns the values of a label->url record in order", () => {
-      expect(
-        donationUrls({
-          "Sponsor A": "https://example.com/donate-a",
-          "Sponsor B": "https://example.com/donate-b",
-        }),
-      ).toEqual([
-        "https://example.com/donate-a",
-        "https://example.com/donate-b",
-      ]);
-    });
-
-    it("returns an empty array for undefined", () => {
-      expect(donationUrls(undefined)).toEqual([]);
-    });
-
-    it("returns an empty array for an empty record", () => {
-      expect(donationUrls({})).toEqual([]);
-    });
-
-    // Empty strings pass through; `donate()` guards against them with `!url`.
-    it("preserves an empty string", () => {
-      expect(donationUrls("")).toEqual([""]);
-    });
-  });
-
   describe("DOCUMENTATIONS.donate()", () => {
     afterEach(() => {
       vi.restoreAllMocks();
@@ -251,7 +217,7 @@ describe("src/documentations.ts", () => {
       const warnSpy = vi.spyOn(self.console, "warn");
 
       expect(() => {
-        DOCUMENTATIONS.donate(brokenDonateView(""));
+        DOCUMENTATIONS.donate(brokenDonateView(undefined));
       }).toThrow("addSetting");
       expect(openExternalSpy).not.toHaveBeenCalled();
       // One warning from the primary listEl path before the deprecated fallback


### PR DESCRIPTION
Fixes #157. On Obsidian 1.12.7+, the donate button and the "open documentation
(donate)" command throw `TypeError: Cannot read properties of undefined (reading
'addSetting')` ("Error opening documentation"). The terminal keeps working; only
donating breaks.

Cause: `donate()` opens the donation link by rendering the plugin's
community-plugins row through the private `renderInstalledPlugin` API and
clicking the heart. Obsidian **1.12.7** changed that private API, so the call throws
(Obsidian logs `Private API changed`). Not a plugin regression:
`git log 3.23.0..HEAD -- src/documentations.ts src/@types/obsidian.ts` is empty
and the line dates to b59e9156. The fragile part is the private-API dependency.

Fix: in the `revealPrivate` failure callback, fall back to
`openExternal(activeSelf(), url)` on the manifest donation URL, and rethrow when
there is no usable URL so the existing error path stays intact. The working
private-API path is unchanged. Adds a `donationUrls()` helper to normalize
`manifest.fundingUrl` (string, record, or missing) and a
`PluginManifest.fundingUrl` type augmentation.

Tests: new `tests/src/documentations.spec.ts` covers `donationUrls()` and a
`donate()` regression that reproduces the #157 throw through `revealPrivate`,
exercising both the fallback and rethrow paths. `bun run test`, `bun run build`,
`bun run commitlint`, and CI are green.

Closes #157.
