### PR TITLE
feat(settings): add toggle to hide Terminal: prefix in tab title

### DIFF
--- a/.changeset/hide-terminal-tab-prefix.md
+++ b/.changeset/hide-terminal-tab-prefix.md
@@ -1,5 +1,0 @@
----
-"obsidian-terminal": minor
----
-
-Add setting to hide the "Terminal:" prefix in tab titles. When enabled, terminal tabs show only the session name (e.g., "bash") instead of "Terminal: bash". Defaults to disabled to preserve existing behaviour. ([GH#170](https://github.com/polyipseity/obsidian-terminal/pull/170) by [@soehme](https://github.com/soehme))

--- a/.changeset/hide-terminal-tab-prefix.md
+++ b/.changeset/hide-terminal-tab-prefix.md
@@ -2,4 +2,4 @@
 "obsidian-terminal": minor
 ---
 
-Add setting to hide the "Terminal:" prefix in tab titles. When enabled, terminal tabs show only the session name (e.g., "bash") instead of "Terminal: bash". Defaults to disabled to preserve existing behaviour. ([#170](https://github.com/polyipseity/obsidian-terminal/pull/170) by [@soehme](https://github.com/soehme))
+Add setting to hide the "Terminal:" prefix in tab titles. When enabled, terminal tabs show only the session name (e.g., "bash") instead of "Terminal: bash". Defaults to disabled to preserve existing behaviour. ([GH#170](https://github.com/polyipseity/obsidian-terminal/pull/170) by [@soehme](https://github.com/soehme))

--- a/.changeset/hide-terminal-tab-prefix.md
+++ b/.changeset/hide-terminal-tab-prefix.md
@@ -2,4 +2,4 @@
 "obsidian-terminal": minor
 ---
 
-Add setting to hide the "Terminal:" prefix in tab titles. When enabled, terminal tabs show only the session name (e.g., "bash") instead of "Terminal: bash". Defaults to disabled to preserve existing behaviour. ([#PR_NUM](https://github.com/polyipseity/obsidian-terminal/pull/PR_NUM) by [@soehme](https://github.com/soehme))
+Add setting to hide the "Terminal:" prefix in tab titles. When enabled, terminal tabs show only the session name (e.g., "bash") instead of "Terminal: bash". Defaults to disabled to preserve existing behaviour. ([#170](https://github.com/polyipseity/obsidian-terminal/pull/170) by [@soehme](https://github.com/soehme))

--- a/.changeset/hide-terminal-tab-prefix.md
+++ b/.changeset/hide-terminal-tab-prefix.md
@@ -1,0 +1,5 @@
+---
+"obsidian-terminal": minor
+---
+
+Add setting to hide the "Terminal:" prefix in tab titles. When enabled, terminal tabs show only the session name (e.g., "bash") instead of "Terminal: bash". Defaults to disabled to preserve existing behaviour. ([#PR_NUM](https://github.com/polyipseity/obsidian-terminal/pull/PR_NUM) by [@soehme](https://github.com/soehme))

--- a/.changeset/show-terminal-tab-prefix.md
+++ b/.changeset/show-terminal-tab-prefix.md
@@ -1,0 +1,5 @@
+---
+"obsidian-terminal": minor
+---
+
+Add setting to show the "Terminal:" prefix in tab titles. When disabled, terminal tabs show only the session name (e.g., "bash") instead of "Terminal: bash". Defaults to enabled to preserve existing behaviour. ([GH#170](https://github.com/polyipseity/obsidian-terminal/pull/170) by [@soehme](https://github.com/soehme))

--- a/assets/locales/af/translation.json
+++ b/assets/locales/af/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/af/translation.json
+++ b/assets/locales/af/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/am/translation.json
+++ b/assets/locales/am/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/am/translation.json
+++ b/assets/locales/am/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/ar/translation.json
+++ b/assets/locales/ar/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/ar/translation.json
+++ b/assets/locales/ar/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/be/translation.json
+++ b/assets/locales/be/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/be/translation.json
+++ b/assets/locales/be/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/bg/translation.json
+++ b/assets/locales/bg/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/bg/translation.json
+++ b/assets/locales/bg/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/bn/translation.json
+++ b/assets/locales/bn/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/bn/translation.json
+++ b/assets/locales/bn/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/ca/translation.json
+++ b/assets/locales/ca/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/ca/translation.json
+++ b/assets/locales/ca/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/cs/translation.json
+++ b/assets/locales/cs/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/cs/translation.json
+++ b/assets/locales/cs/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/da/translation.json
+++ b/assets/locales/da/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/da/translation.json
+++ b/assets/locales/da/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/de/translation.json
+++ b/assets/locales/de/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/de/translation.json
+++ b/assets/locales/de/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/el/translation.json
+++ b/assets/locales/el/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/el/translation.json
+++ b/assets/locales/el/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/en/asset.json
+++ b/assets/locales/en/asset.json
@@ -140,6 +140,7 @@
     "expose-internal-modules-icon": "puzzle",
     "focus-on-new-instance-icon": "$t(asset:generic.actions.focus-icon)",
     "hide-status-bar-icon": "eye-off",
+    "hide-terminal-tab-prefix-icon": "tag",
     "intercept-keys-when-focused-icon": "keyboard",
     "intercept-logging-icon": "scroll-text",
     "keymappings-edit-icon": "$t(asset:generic.edit-list-icon)",

--- a/assets/locales/en/asset.json
+++ b/assets/locales/en/asset.json
@@ -140,7 +140,7 @@
     "expose-internal-modules-icon": "puzzle",
     "focus-on-new-instance-icon": "$t(asset:generic.actions.focus-icon)",
     "hide-status-bar-icon": "eye-off",
-    "hide-terminal-tab-prefix-icon": "tag",
+    "show-terminal-tab-prefix-icon": "tag",
     "intercept-keys-when-focused-icon": "keyboard",
     "intercept-logging-icon": "scroll-text",
     "keymappings-edit-icon": "$t(asset:generic.edit-list-icon)",

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -361,6 +361,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -361,8 +361,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/eo/translation.json
+++ b/assets/locales/eo/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/eo/translation.json
+++ b/assets/locales/eo/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/es/translation.json
+++ b/assets/locales/es/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/es/translation.json
+++ b/assets/locales/es/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/eu/translation.json
+++ b/assets/locales/eu/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/eu/translation.json
+++ b/assets/locales/eu/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/fa/translation.json
+++ b/assets/locales/fa/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/fa/translation.json
+++ b/assets/locales/fa/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/fi/translation.json
+++ b/assets/locales/fi/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/fi/translation.json
+++ b/assets/locales/fi/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/fr/translation.json
+++ b/assets/locales/fr/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/fr/translation.json
+++ b/assets/locales/fr/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/gl/translation.json
+++ b/assets/locales/gl/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/gl/translation.json
+++ b/assets/locales/gl/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/he/translation.json
+++ b/assets/locales/he/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/he/translation.json
+++ b/assets/locales/he/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/hi/translation.json
+++ b/assets/locales/hi/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/hi/translation.json
+++ b/assets/locales/hi/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/hu/translation.json
+++ b/assets/locales/hu/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/hu/translation.json
+++ b/assets/locales/hu/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/id/translation.json
+++ b/assets/locales/id/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/id/translation.json
+++ b/assets/locales/id/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/it/translation.json
+++ b/assets/locales/it/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/it/translation.json
+++ b/assets/locales/it/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/ja/translation.json
+++ b/assets/locales/ja/translation.json
@@ -356,6 +356,8 @@
       "never": "しない",
       "running": "$t(generic.terminal)が実行中の時"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/ja/translation.json
+++ b/assets/locales/ja/translation.json
@@ -356,8 +356,6 @@
       "never": "しない",
       "running": "$t(generic.terminal)が実行中の時"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other)",
     "profiles-description": "$t(generic.list-description)",
     "profiles-edit": "$t(generic.edit)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/ko/translation.json
+++ b/assets/locales/ko/translation.json
@@ -356,6 +356,8 @@
       "never": "절대",
       "running": "$t(generic.terminal)이 실행 중인 경우"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/ko/translation.json
+++ b/assets/locales/ko/translation.json
@@ -356,8 +356,6 @@
       "never": "절대",
       "running": "$t(generic.terminal)이 실행 중인 경우"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other)",
     "profiles-description": "$t(generic.list-description)",
     "profiles-edit": "$t(generic.edit)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/lv/translation.json
+++ b/assets/locales/lv/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/lv/translation.json
+++ b/assets/locales/lv/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/ml/translation.json
+++ b/assets/locales/ml/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/ml/translation.json
+++ b/assets/locales/ml/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/ms/translation.json
+++ b/assets/locales/ms/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/ms/translation.json
+++ b/assets/locales/ms/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/nl/translation.json
+++ b/assets/locales/nl/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/nl/translation.json
+++ b/assets/locales/nl/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/no/translation.json
+++ b/assets/locales/no/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/no/translation.json
+++ b/assets/locales/no/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/oc/translation.json
+++ b/assets/locales/oc/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/oc/translation.json
+++ b/assets/locales/oc/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/pl/translation.json
+++ b/assets/locales/pl/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/pl/translation.json
+++ b/assets/locales/pl/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/pt-BR/translation.json
+++ b/assets/locales/pt-BR/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/pt-BR/translation.json
+++ b/assets/locales/pt-BR/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/pt/translation.json
+++ b/assets/locales/pt/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/pt/translation.json
+++ b/assets/locales/pt/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/ro/translation.json
+++ b/assets/locales/ro/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/ro/translation.json
+++ b/assets/locales/ro/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/ru/translation.json
+++ b/assets/locales/ru/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/ru/translation.json
+++ b/assets/locales/ru/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/se/translation.json
+++ b/assets/locales/se/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/se/translation.json
+++ b/assets/locales/se/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/sk/translation.json
+++ b/assets/locales/sk/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/sk/translation.json
+++ b/assets/locales/sk/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/sq/translation.json
+++ b/assets/locales/sq/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/sq/translation.json
+++ b/assets/locales/sq/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/sr/translation.json
+++ b/assets/locales/sr/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/sr/translation.json
+++ b/assets/locales/sr/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/ta/translation.json
+++ b/assets/locales/ta/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/ta/translation.json
+++ b/assets/locales/ta/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/te/translation.json
+++ b/assets/locales/te/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/te/translation.json
+++ b/assets/locales/te/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/th/translation.json
+++ b/assets/locales/th/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/th/translation.json
+++ b/assets/locales/th/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/tr/translation.json
+++ b/assets/locales/tr/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/tr/translation.json
+++ b/assets/locales/tr/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/uk/translation.json
+++ b/assets/locales/uk/translation.json
@@ -356,6 +356,8 @@
       "never": "Ніколи",
       "running": "Коли термінал запущений"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/uk/translation.json
+++ b/assets/locales/uk/translation.json
@@ -356,8 +356,6 @@
       "never": "Ніколи",
       "running": "Коли термінал запущений"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Застосовуються до кожного профілю, якщо не перевизначені явно.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/ur/translation.json
+++ b/assets/locales/ur/translation.json
@@ -356,6 +356,8 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",

--- a/assets/locales/ur/translation.json
+++ b/assets/locales/ur/translation.json
@@ -356,8 +356,6 @@
       "never": "Never",
       "running": "When $t(generic.terminal) is running"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance_gerund, capitalize)",
     "intercept-keys-when-focused": "$t(generic.intercept, capitalize) keys when $t(generic.terminal) is $t(generic.focus_past-participle)",
     "intercept-keys-when-focused-description": "When enabled, keyboard shortcuts are routed to $t(generic.terminal)-specific commands while the $t(generic.terminal) is $t(generic.focus_past-participle), and most Obsidian hotkeys are suppressed. Disable to let Obsidian hotkeys continue to work while typing in the $t(generic.terminal).",
@@ -393,6 +391,8 @@
     "profiles": "$t(generic.profile_other, capitalize)",
     "profiles-description": "$t(generic.list-description, capitalize)",
     "profiles-edit": "$t(generic.edit, capitalize)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "Shallow-merged into every $t(generic.profile) unless a specific $t(generic.profile) explicitly overrides them.",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/zh-Hans/translation.json
+++ b/assets/locales/zh-Hans/translation.json
@@ -67,6 +67,11 @@
       },
       "follow-theme": "$t(generic.follow)$t(generic.theme)",
       "integrated": {
+        "Python-executable": "$t(generic.Python)$t(generic.executable)",
+        "Python-executable-check": "$t(generic.check)",
+        "Python-executable-checking": "$t(generic.check)中",
+        "Python-executable-description": "推荐{{version}}或更高版本。于$t(generic.platforms.unix)$t(generic.spawn)$t(generic.profile-types.integrated)$t(generic.terminal)所需要的。$t(generic.clear)$t(generic.text-field)以$t(generic.disable)$t(generic.Python)。",
+        "Python-executable-placeholder": "（已$t(generic.disable)）",
         "arguments": "$t(generic.argument)",
         "arguments-description": "$t(generic.list-description)",
         "arguments-edit": "$t(generic.edit)",
@@ -77,11 +82,6 @@
         "environment-list-description": "对于重复的键，以最后一项为准。键和值中的前后空白会按原样保留。在$t(generic.platforms.win32)上，变量名不区分大小写；在应用这些条目前，会先移除名称与任一条目键名大小写不敏感匹配的现有变量。这是因为 Node.js 会按字典序排序环境变量键，并且只将第一个大小写不敏感匹配项传递给子进程。",
         "environment-value-placeholder": "值",
         "executable": "$t(generic.executable)",
-        "Python-executable": "$t(generic.Python)$t(generic.executable)",
-        "Python-executable-check": "$t(generic.check)",
-        "Python-executable-checking": "$t(generic.check)中",
-        "Python-executable-description": "推荐{{version}}或更高版本。于$t(generic.platforms.unix)$t(generic.spawn)$t(generic.profile-types.integrated)$t(generic.terminal)所需要的。$t(generic.clear)$t(generic.text-field)以$t(generic.disable)$t(generic.Python)。",
-        "Python-executable-placeholder": "（已$t(generic.disable)）",
         "use-win32-conhost": "$t(generic.use)$t(generic.platforms.win32)「conhost.exe」",
         "use-win32-conhost-description": "如果执行「conhost.exe」没有创建视窗，请$t(generic.disable)。不保证这会起作用。"
       },
@@ -174,6 +174,7 @@
     "resizer-exited-unexpectedly": "$t(generic.terminal-resizer)意外$t(generic.exit)：{{code}}"
   },
   "generic": {
+    "Python": "Python",
     "argument": "参数",
     "behavior": "行为",
     "check": "检查",
@@ -236,7 +237,6 @@
       "select": "选择"
     },
     "pseudoterminal": "伪终端",
-    "Python": "Python",
     "rename": "rename",
     "renderer": "渲染器",
     "renderers": {
@@ -272,9 +272,9 @@
   },
   "name": "$t(generic.terminal)",
   "notices": {
-    "no-default-profile": "没有$t(generic.type)「$t(generic.profile-types.{{type}})」的$t(generic.default)$t(generic.profile)",
     "Python-status-entry-": "{{name}}：{{version}}（满足：{{requirement}}）",
     "Python-status-entry-unsatisfied": "{{name}}：{{version}}（未满足：{{requirement}}）",
+    "no-default-profile": "没有$t(generic.type)「$t(generic.profile-types.{{type}})」的$t(generic.default)$t(generic.profile)",
     "spawning-terminal": "$t(generic.terminal)$t(generic.spawn)中：{{title}}",
     "terminal-exited": "$t(generic.terminal)已$t(generic.exit)：{{code}}"
   },
@@ -340,6 +340,8 @@
       "never": "从不",
       "running": "当执行$t(generic.terminal)时"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance)",
     "intercept-keys-when-focused": "$t(generic.intercept)$t(generic.terminal)获得焦点时的按键",
     "intercept-keys-when-focused-description": "启用此项后，当$t(generic.terminal)获得焦点时，按键将优先路由至$t(generic.terminal)命令，大部分 Obsidian 快捷键会被禁用。禁用此项可在$t(generic.terminal)获得焦点时继续使用 Obsidian 快捷键。",

--- a/assets/locales/zh-Hans/translation.json
+++ b/assets/locales/zh-Hans/translation.json
@@ -340,8 +340,6 @@
       "never": "从不",
       "running": "当执行$t(generic.terminal)时"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance)",
     "intercept-keys-when-focused": "$t(generic.intercept)$t(generic.terminal)获得焦点时的按键",
     "intercept-keys-when-focused-description": "启用此项后，当$t(generic.terminal)获得焦点时，按键将优先路由至$t(generic.terminal)命令，大部分 Obsidian 快捷键会被禁用。禁用此项可在$t(generic.terminal)获得焦点时继续使用 Obsidian 快捷键。",
@@ -377,6 +375,8 @@
     "profiles": "$t(generic.profile)",
     "profiles-description": "$t(generic.list-description)",
     "profiles-edit": "$t(generic.edit)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "除非特定$t(generic.profile)明确覆盖它们，否则它们会被浅合并到每个$t(generic.profile)中。",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/assets/locales/zh-Hant/translation.json
+++ b/assets/locales/zh-Hant/translation.json
@@ -340,6 +340,8 @@
       "never": "從不",
       "running": "當執行$t(generic.terminal)時"
     },
+    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
+    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance)",
     "intercept-keys-when-focused": "$t(generic.intercept)$t(generic.terminal)獲得焦點時的按鍵",
     "intercept-keys-when-focused-description": "啟用此項後，當$t(generic.terminal)獲得焦點時，按鍵將優先路由至$t(generic.terminal)命令，大部份 Obsidian 快捷鍵會被停用。停用此項可在$t(generic.terminal)獲得焦點時繼續使用 Obsidian 快捷鍵。",

--- a/assets/locales/zh-Hant/translation.json
+++ b/assets/locales/zh-Hant/translation.json
@@ -340,8 +340,6 @@
       "never": "從不",
       "running": "當執行$t(generic.terminal)時"
     },
-    "hide-terminal-tab-prefix": "Hide Terminal: prefix in tab title",
-    "hide-terminal-tab-prefix-description": "When enabled, terminal tabs show only the session name (e.g. bash) instead of Terminal: bash. The terminal icon still identifies the tab type.",
     "instancing": "$t(generic.instance)",
     "intercept-keys-when-focused": "$t(generic.intercept)$t(generic.terminal)獲得焦點時的按鍵",
     "intercept-keys-when-focused-description": "啟用此項後，當$t(generic.terminal)獲得焦點時，按鍵將優先路由至$t(generic.terminal)命令，大部份 Obsidian 快捷鍵會被停用。停用此項可在$t(generic.terminal)獲得焦點時繼續使用 Obsidian 快捷鍵。",
@@ -377,6 +375,8 @@
     "profiles": "$t(generic.profile)",
     "profiles-description": "$t(generic.list-description)",
     "profiles-edit": "$t(generic.edit)",
+    "show-terminal-tab-prefix": "Show $t(generic.terminal) tab prefix",
+    "show-terminal-tab-prefix-description": "When disabled, $t(generic.terminal) tabs show only the session name (e.g. bash) instead of \"$t(generic.terminal): bash\".",
     "terminal-options": "$t(generic.terminal-option_other, capitalize)",
     "terminal-options-description": "除非特定$t(generic.profile)明確覆蓋它們，否則它們會被淺合併到每個$t(generic.profile)中。",
     "terminal-options-edit": "$t(generic.edit, capitalize)"

--- a/src/settings-data.ts
+++ b/src/settings-data.ts
@@ -86,8 +86,8 @@ export interface Settings extends PluginContext.Settings {
   readonly focusOnNewInstance: boolean;
   readonly pinNewInstance: boolean;
 
-  readonly hideTerminalTabPrefix: boolean;
   readonly openChangelogOnUpdate: boolean;
+  readonly showTerminalTabPrefix: boolean;
   readonly hideStatusBar: Settings.HideStatusBarOption;
 
   readonly exposeInternalModules: boolean;
@@ -120,7 +120,6 @@ export namespace Settings {
     exposeInternalModules: true,
     focusOnNewInstance: true,
     hideStatusBar: "focused",
-    hideTerminalTabPrefix: false,
     interceptKeysWhenFocused: true,
     interceptLogging: true,
     keymappings: [
@@ -265,6 +264,7 @@ export namespace Settings {
     newInstanceBehavior: "newHorizontalSplit",
     noticeTimeout: 5,
     openChangelogOnUpdate: true,
+    showTerminalTabPrefix: true,
     pinNewInstance: true,
     preferredRenderer: "webgl",
     profiles: Object.fromEntries(
@@ -1551,9 +1551,6 @@ export namespace Settings {
         "hideStatusBar",
         HIDE_STATUS_BAR_OPTIONS,
       ),
-      hideTerminalTabPrefix: fixTyped(DEFAULT, unc, "hideTerminalTabPrefix", [
-        "boolean",
-      ]),
       interceptKeysWhenFocused: fixTyped(
         DEFAULT,
         unc,
@@ -1583,6 +1580,9 @@ export namespace Settings {
       ),
       noticeTimeout: fixTyped(DEFAULT, unc, "noticeTimeout", ["number"]),
       openChangelogOnUpdate: fixTyped(DEFAULT, unc, "openChangelogOnUpdate", [
+        "boolean",
+      ]),
+      showTerminalTabPrefix: fixTyped(DEFAULT, unc, "showTerminalTabPrefix", [
         "boolean",
       ]),
       pinNewInstance: fixTyped(DEFAULT, unc, "pinNewInstance", ["boolean"]),

--- a/src/settings-data.ts
+++ b/src/settings-data.ts
@@ -86,6 +86,7 @@ export interface Settings extends PluginContext.Settings {
   readonly focusOnNewInstance: boolean;
   readonly pinNewInstance: boolean;
 
+  readonly hideTerminalTabPrefix: boolean;
   readonly openChangelogOnUpdate: boolean;
   readonly hideStatusBar: Settings.HideStatusBarOption;
 
@@ -119,6 +120,7 @@ export namespace Settings {
     exposeInternalModules: true,
     focusOnNewInstance: true,
     hideStatusBar: "focused",
+    hideTerminalTabPrefix: false,
     interceptKeysWhenFocused: true,
     interceptLogging: true,
     keymappings: [
@@ -1549,6 +1551,9 @@ export namespace Settings {
         "hideStatusBar",
         HIDE_STATUS_BAR_OPTIONS,
       ),
+      hideTerminalTabPrefix: fixTyped(DEFAULT, unc, "hideTerminalTabPrefix", [
+        "boolean",
+      ]),
       interceptKeysWhenFocused: fixTyped(
         DEFAULT,
         unc,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -598,6 +598,37 @@ export class SettingTab extends AdvancedSettingTab<Settings> {
     })
       .newSetting(containerEl, (setting) => {
         setting
+          .setName(i18n.t("settings.show-terminal-tab-prefix"))
+          .setDesc(i18n.t("settings.show-terminal-tab-prefix-description"))
+          .addToggle(
+            linkSetting(
+              () => settings.value.showTerminalTabPrefix,
+              async (value) =>
+                settings.mutate((settingsM) => {
+                  settingsM.showTerminalTabPrefix = value;
+                }),
+              () => {
+                this.postMutate();
+              },
+            ),
+          )
+          .addExtraButton(
+            resetButton(
+              i18n.t("asset:settings.show-terminal-tab-prefix-icon"),
+              i18n.t("settings.reset"),
+              async () =>
+                settings.mutate((settingsM) => {
+                  settingsM.showTerminalTabPrefix =
+                    Settings.DEFAULT.showTerminalTabPrefix;
+                }),
+              () => {
+                this.postMutate();
+              },
+            ),
+          );
+      })
+      .newSetting(containerEl, (setting) => {
+        setting
           .setName(i18n.t("settings.hide-status-bar"))
           .addDropdown(
             linkSetting(
@@ -631,37 +662,6 @@ export class SettingTab extends AdvancedSettingTab<Settings> {
               async () =>
                 settings.mutate((settingsM) => {
                   settingsM.hideStatusBar = Settings.DEFAULT.hideStatusBar;
-                }),
-              () => {
-                this.postMutate();
-              },
-            ),
-          );
-      })
-      .newSetting(containerEl, (setting) => {
-        setting
-          .setName(i18n.t("settings.hide-terminal-tab-prefix"))
-          .setDesc(i18n.t("settings.hide-terminal-tab-prefix-description"))
-          .addToggle(
-            linkSetting(
-              () => settings.value.hideTerminalTabPrefix,
-              async (value) =>
-                settings.mutate((settingsM) => {
-                  settingsM.hideTerminalTabPrefix = value;
-                }),
-              () => {
-                this.postMutate();
-              },
-            ),
-          )
-          .addExtraButton(
-            resetButton(
-              i18n.t("asset:settings.hide-terminal-tab-prefix-icon"),
-              i18n.t("settings.reset"),
-              async () =>
-                settings.mutate((settingsM) => {
-                  settingsM.hideTerminalTabPrefix =
-                    Settings.DEFAULT.hideTerminalTabPrefix;
                 }),
               () => {
                 this.postMutate();

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -595,48 +595,80 @@ export class SettingTab extends AdvancedSettingTab<Settings> {
             },
           ),
         );
-    }).newSetting(containerEl, (setting) => {
-      setting
-        .setName(i18n.t("settings.hide-status-bar"))
-        .addDropdown(
-          linkSetting(
-            (): string => settings.value.hideStatusBar,
-            setTextToEnum(Settings.HIDE_STATUS_BAR_OPTIONS, async (value) =>
-              settings.mutate((settingsM) => {
-                settingsM.hideStatusBar = value;
-              }),
-            ),
-            () => {
-              this.postMutate();
-            },
-            {
-              pre: (dropdown) => {
-                dropdown.addOptions(
-                  Object.fromEntries(
-                    Settings.HIDE_STATUS_BAR_OPTIONS.map((value) => [
-                      value,
-                      i18n.t(`settings.hide-status-bar-options.${value}`),
-                    ]),
-                  ),
-                );
+    })
+      .newSetting(containerEl, (setting) => {
+        setting
+          .setName(i18n.t("settings.hide-status-bar"))
+          .addDropdown(
+            linkSetting(
+              (): string => settings.value.hideStatusBar,
+              setTextToEnum(Settings.HIDE_STATUS_BAR_OPTIONS, async (value) =>
+                settings.mutate((settingsM) => {
+                  settingsM.hideStatusBar = value;
+                }),
+              ),
+              () => {
+                this.postMutate();
               },
-            },
-          ),
-        )
-        .addExtraButton(
-          resetButton(
-            i18n.t("asset:settings.hide-status-bar-icon"),
-            i18n.t("settings.reset"),
-            async () =>
-              settings.mutate((settingsM) => {
-                settingsM.hideStatusBar = Settings.DEFAULT.hideStatusBar;
-              }),
-            () => {
-              this.postMutate();
-            },
-          ),
-        );
-    });
+              {
+                pre: (dropdown) => {
+                  dropdown.addOptions(
+                    Object.fromEntries(
+                      Settings.HIDE_STATUS_BAR_OPTIONS.map((value) => [
+                        value,
+                        i18n.t(`settings.hide-status-bar-options.${value}`),
+                      ]),
+                    ),
+                  );
+                },
+              },
+            ),
+          )
+          .addExtraButton(
+            resetButton(
+              i18n.t("asset:settings.hide-status-bar-icon"),
+              i18n.t("settings.reset"),
+              async () =>
+                settings.mutate((settingsM) => {
+                  settingsM.hideStatusBar = Settings.DEFAULT.hideStatusBar;
+                }),
+              () => {
+                this.postMutate();
+              },
+            ),
+          );
+      })
+      .newSetting(containerEl, (setting) => {
+        setting
+          .setName(i18n.t("settings.hide-terminal-tab-prefix"))
+          .setDesc(i18n.t("settings.hide-terminal-tab-prefix-description"))
+          .addToggle(
+            linkSetting(
+              () => settings.value.hideTerminalTabPrefix,
+              async (value) =>
+                settings.mutate((settingsM) => {
+                  settingsM.hideTerminalTabPrefix = value;
+                }),
+              () => {
+                this.postMutate();
+              },
+            ),
+          )
+          .addExtraButton(
+            resetButton(
+              i18n.t("asset:settings.hide-terminal-tab-prefix-icon"),
+              i18n.t("settings.reset"),
+              async () =>
+                settings.mutate((settingsM) => {
+                  settingsM.hideTerminalTabPrefix =
+                    Settings.DEFAULT.hideTerminalTabPrefix;
+                }),
+              () => {
+                this.postMutate();
+              },
+            ),
+          );
+      });
     this.newNoticeTimeoutWidget(Settings.DEFAULT);
     this.newSectionWidget(() => i18n.t("settings.advanced"));
     ui.newSetting(containerEl, (setting) => {

--- a/src/terminal/view.ts
+++ b/src/terminal/view.ts
@@ -643,7 +643,7 @@ export class TerminalView extends ItemView {
   }
 
   public getDisplayText(): string {
-    if (this.context.settings.value.hideTerminalTabPrefix) {
+    if (!this.context.settings.value.showTerminalTabPrefix) {
       return this.title;
     }
     return this.context.language.value.t(
@@ -900,7 +900,7 @@ export class TerminalView extends ItemView {
     );
     this.register(
       settings.onMutate(
-        (s) => s.hideTerminalTabPrefix,
+        (s) => s.showTerminalTabPrefix,
         () => {
           updateView(context, this);
         },

--- a/src/terminal/view.ts
+++ b/src/terminal/view.ts
@@ -643,6 +643,9 @@ export class TerminalView extends ItemView {
   }
 
   public getDisplayText(): string {
+    if (this.context.settings.value.hideTerminalTabPrefix) {
+      return this.title;
+    }
     return this.context.language.value.t(
       `components.${TerminalView.type.id}.display-name`,
       {

--- a/src/terminal/view.ts
+++ b/src/terminal/view.ts
@@ -898,6 +898,14 @@ export class TerminalView extends ItemView {
         },
       ),
     );
+    this.register(
+      settings.onMutate(
+        (s) => s.hideTerminalTabPrefix,
+        () => {
+          updateView(context, this);
+        },
+      ),
+    );
 
     this.register(statusBarHider.hide(() => this.hidesStatusBar));
     this.register(() => {

--- a/tests/src/settings-data.spec.ts
+++ b/tests/src/settings-data.spec.ts
@@ -10,6 +10,8 @@ describe("src/settings-data.ts", () => {
     expect(typeof Settings.DEFAULT.noticeTimeout).toBe("number");
     expect(Settings.DEFAULT).toHaveProperty("openChangelogOnUpdate");
     expect(typeof Settings.DEFAULT.openChangelogOnUpdate).toBe("boolean");
+    expect(Settings.DEFAULT).toHaveProperty("hideTerminalTabPrefix");
+    expect(Settings.DEFAULT.hideTerminalTabPrefix).toBe(false);
     expect(Settings.DEFAULT).toHaveProperty("terminalOptions");
     expect(typeof Settings.DEFAULT.terminalOptions).toBe("object");
     // should at least include the documentOverride property from the preset
@@ -143,6 +145,22 @@ describe("src/settings-data.ts", () => {
       defaultProfile: 123 as any,
     });
     expect(alsoBad.value.defaultProfile).toBe(null);
+  });
+
+  it("Settings.fix preserves valid hideTerminalTabPrefix", () => {
+    const enabled = Settings.fix({ hideTerminalTabPrefix: true });
+    expect(enabled.value.hideTerminalTabPrefix).toBe(true);
+
+    const disabled = Settings.fix({ hideTerminalTabPrefix: false });
+    expect(disabled.value.hideTerminalTabPrefix).toBe(false);
+  });
+
+  it("Settings.fix coerces bad hideTerminalTabPrefix to default", () => {
+    const bad = Settings.fix({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      hideTerminalTabPrefix: "not-a-boolean" as any,
+    });
+    expect(bad.value.hideTerminalTabPrefix).toBe(false);
   });
 
   describe("Settings.Profile.defaultEntryOfType", () => {

--- a/tests/src/settings-data.spec.ts
+++ b/tests/src/settings-data.spec.ts
@@ -10,8 +10,8 @@ describe("src/settings-data.ts", () => {
     expect(typeof Settings.DEFAULT.noticeTimeout).toBe("number");
     expect(Settings.DEFAULT).toHaveProperty("openChangelogOnUpdate");
     expect(typeof Settings.DEFAULT.openChangelogOnUpdate).toBe("boolean");
-    expect(Settings.DEFAULT).toHaveProperty("hideTerminalTabPrefix");
-    expect(Settings.DEFAULT.hideTerminalTabPrefix).toBe(false);
+    expect(Settings.DEFAULT).toHaveProperty("showTerminalTabPrefix");
+    expect(Settings.DEFAULT.showTerminalTabPrefix).toBe(true);
     expect(Settings.DEFAULT).toHaveProperty("terminalOptions");
     expect(typeof Settings.DEFAULT.terminalOptions).toBe("object");
     // should at least include the documentOverride property from the preset
@@ -147,20 +147,20 @@ describe("src/settings-data.ts", () => {
     expect(alsoBad.value.defaultProfile).toBe(null);
   });
 
-  it("Settings.fix preserves valid hideTerminalTabPrefix", () => {
-    const enabled = Settings.fix({ hideTerminalTabPrefix: true });
-    expect(enabled.value.hideTerminalTabPrefix).toBe(true);
+  it("Settings.fix preserves valid showTerminalTabPrefix", () => {
+    const enabled = Settings.fix({ showTerminalTabPrefix: true });
+    expect(enabled.value.showTerminalTabPrefix).toBe(true);
 
-    const disabled = Settings.fix({ hideTerminalTabPrefix: false });
-    expect(disabled.value.hideTerminalTabPrefix).toBe(false);
+    const disabled = Settings.fix({ showTerminalTabPrefix: false });
+    expect(disabled.value.showTerminalTabPrefix).toBe(false);
   });
 
-  it("Settings.fix coerces bad hideTerminalTabPrefix to default", () => {
+  it("Settings.fix coerces bad showTerminalTabPrefix to default", () => {
     const bad = Settings.fix({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      hideTerminalTabPrefix: "not-a-boolean" as any,
+      showTerminalTabPrefix: "not-a-boolean" as any,
     });
-    expect(bad.value.hideTerminalTabPrefix).toBe(false);
+    expect(bad.value.showTerminalTabPrefix).toBe(true);
   });
 
   describe("Settings.Profile.defaultEntryOfType", () => {

--- a/tests/src/terminal/view.spec.ts
+++ b/tests/src/terminal/view.spec.ts
@@ -144,12 +144,12 @@ describe("src/terminal/view.ts", () => {
   });
 
   describe("getDisplayText", () => {
-    it("returns title directly when hideTerminalTabPrefix is enabled", async () => {
+    it("returns title directly when showTerminalTabPrefix is disabled", async () => {
       const { WorkspaceLeaf } = await import("obsidian");
       const mockI18n = { t: vi.fn((key: string) => key) };
       const mockContext = {
         language: { value: mockI18n },
-        settings: { value: { hideTerminalTabPrefix: true } },
+        settings: { value: { showTerminalTabPrefix: false } },
       } as unknown as ConstructorParameters<typeof TerminalView>[0];
       const leaf = new WorkspaceLeaf();
       const view = new TerminalView(mockContext, leaf);
@@ -162,12 +162,12 @@ describe("src/terminal/view.ts", () => {
       expect(result).toBe("components.terminal.name.profile-type");
     });
 
-    it("returns localized display-name when hideTerminalTabPrefix is disabled", async () => {
+    it("returns localized display-name when showTerminalTabPrefix is enabled", async () => {
       const { WorkspaceLeaf } = await import("obsidian");
       const mockI18n = { t: vi.fn((key: string) => key) };
       const mockContext = {
         language: { value: mockI18n },
-        settings: { value: { hideTerminalTabPrefix: false } },
+        settings: { value: { showTerminalTabPrefix: true } },
       } as unknown as ConstructorParameters<typeof TerminalView>[0];
       const leaf = new WorkspaceLeaf();
       const view = new TerminalView(mockContext, leaf);

--- a/tests/src/terminal/view.spec.ts
+++ b/tests/src/terminal/view.spec.ts
@@ -142,4 +142,42 @@ describe("src/terminal/view.ts", () => {
       });
     });
   });
+
+  describe("getDisplayText", () => {
+    it("returns title directly when hideTerminalTabPrefix is enabled", async () => {
+      const { WorkspaceLeaf } = await import("obsidian");
+      const mockI18n = { t: vi.fn((key: string) => key) };
+      const mockContext = {
+        language: { value: mockI18n },
+        settings: { value: { hideTerminalTabPrefix: true } },
+      } as unknown as ConstructorParameters<typeof TerminalView>[0];
+      const leaf = new WorkspaceLeaf();
+      const view = new TerminalView(mockContext, leaf);
+
+      const result = view.getDisplayText();
+      expect(mockI18n.t).toHaveBeenCalledWith(
+        "components.terminal.name.profile-type",
+        expect.any(Object),
+      );
+      expect(result).toBe("components.terminal.name.profile-type");
+    });
+
+    it("returns localized display-name when hideTerminalTabPrefix is disabled", async () => {
+      const { WorkspaceLeaf } = await import("obsidian");
+      const mockI18n = { t: vi.fn((key: string) => key) };
+      const mockContext = {
+        language: { value: mockI18n },
+        settings: { value: { hideTerminalTabPrefix: false } },
+      } as unknown as ConstructorParameters<typeof TerminalView>[0];
+      const leaf = new WorkspaceLeaf();
+      const view = new TerminalView(mockContext, leaf);
+
+      const result = view.getDisplayText();
+      expect(mockI18n.t).toHaveBeenCalledWith(
+        "components.terminal.display-name",
+        expect.objectContaining({ title: expect.any(String) }),
+      );
+      expect(result).toBe("components.terminal.display-name");
+    });
+  });
 });


### PR DESCRIPTION
Closes #169

## What
Adds a boolean setting **"Hide 'Terminal:' prefix in tab title"** (default: off).

When enabled, `getDisplayText()` returns `this.title` directly instead of the full i18n string, so tabs show e.g. `bash` instead of `Terminal: bash`.

## Why
The `Terminal:` prefix is redundant when many tabs are open — the terminal icon already signals the tab type. This frees horizontal space with no behaviour change for users who don't opt in.

## Changes
- `src/settings-data.ts` — new `hideTerminalTabPrefix: boolean` field + `.fix()` validator
- `src/terminal/view.ts` — conditional in `getDisplayText()`
- `src/settings.ts` — toggle in Interface section of settings tab
- `assets/locales/en/translation.json` + `asset.json` — i18n keys
- `.changeset/hide-terminal-tab-prefix.md` — changeset (minor)