### PR TITLE
feat: open vault-relative .md links in Obsidian viewer

### DIFF
--- a/.changeset/vault-md-file-links.md
+++ b/.changeset/vault-md-file-links.md
@@ -1,0 +1,5 @@
+---
+"obsidian-terminal": minor
+---
+
+Add clickable vault-relative Markdown file links in terminal output. `.md` paths (parenthesized or bare) open in Obsidian's built-in Markdown viewer on click instead of the system default. Uses `get-east-asian-width` for CJK column range calculation in xterm.js. ([GH#171](https://github.com/polyipseity/obsidian-terminal/pull/171) by [@jaden2dev](https://github.com/jaden2dev))

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "ansi-escape-sequences": "^6.2.4",
         "async-lock": "^1.4.1",
         "browser-util-inspect": "^0.2.0",
+        "get-east-asian-width": "^1.6.0",
         "i18next": "^26.0.10",
         "immutable": "^5.1.5",
         "lodash-es": "^4.18.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "ansi-escape-sequences": "^6.2.4",
     "async-lock": "^1.4.1",
     "browser-util-inspect": "^0.2.0",
+    "get-east-asian-width": "^1.6.0",
     "i18next": "^26.0.10",
     "immutable": "^5.1.5",
     "lodash-es": "^4.18.1",

--- a/src/terminal/emulator-addons.ts
+++ b/src/terminal/emulator-addons.ts
@@ -1110,14 +1110,11 @@ export class VaultFileLinksAddon implements ITerminalAddon {
               start: { x: startX, y: bufferLineNumber },
             },
             text: filePath,
-            activate(_event: MouseEvent, text: string): void {
-              const vaultFile = app.vault.getFileByPath(text);
-              if (!vaultFile) {
-                return;
-              }
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            activate(_event: MouseEvent, _text: string): void {
               app.workspace
                 .getLeaf(false)
-                .openFile(vaultFile)
+                .openFile(file)
                 .catch((error: unknown) => {
                   activeSelf(terminal.element).console.error(error);
                 });

--- a/src/terminal/emulator-addons.ts
+++ b/src/terminal/emulator-addons.ts
@@ -1123,11 +1123,16 @@ export class VaultFileLinksAddon implements ITerminalAddon {
           });
         };
 
+        const parenRanges: { start: number; end: number }[] = [];
         for (const match of lineText.matchAll(
           VaultFileLinksAddon.#PAREN_REGEX,
         )) {
           if (match[1] !== undefined) {
             addLink(match[1], match.index + 1); // +1 skips the opening `(`
+            parenRanges.push({
+              start: match.index + 1,
+              end: match.index + 1 + match[1].length,
+            });
           }
         }
 
@@ -1136,7 +1141,14 @@ export class VaultFileLinksAddon implements ITerminalAddon {
         )) {
           if (match[1] !== undefined) {
             const prefixLen = match[0].length - match[1].length;
-            addLink(match[1], match.index + prefixLen);
+            const bareStart = match.index + prefixLen;
+            const bareEnd = bareStart + match[1].length;
+            if (
+              parenRanges.some((r) => bareStart >= r.start && bareEnd <= r.end)
+            ) {
+              continue;
+            }
+            addLink(match[1], bareStart);
           }
         }
 

--- a/src/terminal/emulator-addons.ts
+++ b/src/terminal/emulator-addons.ts
@@ -1,4 +1,3 @@
-import { eastAsianWidth } from "get-east-asian-width";
 import {
   Functions,
   type PluginContext,
@@ -13,6 +12,7 @@ import {
 import type { CanvasAddon } from "@xterm/addon-canvas";
 import type { WebglAddon } from "@xterm/addon-webgl";
 import type { ILink, ITerminalAddon, ITheme, Terminal } from "@xterm/xterm";
+import { eastAsianWidth } from "get-east-asian-width";
 import { constant, isUndefined } from "lodash-es";
 import { around } from "monkey-around";
 import { noop } from "ts-essentials";
@@ -1084,75 +1084,32 @@ export class VaultFileLinksAddon implements ITerminalAddon {
     } = this;
 
     const disposable = terminal.registerLinkProvider({
-      provideLinks(
+      provideLinks: (
         bufferLineNumber: number,
         callback: (links: ILink[] | undefined) => void,
-      ): void {
-        // getLine uses 0-based index; bufferLineNumber is 1-based
+      ): void => {
         const line = terminal.buffer.active.getLine(bufferLineNumber - 1);
         if (!line) {
-          callback(undefined);
+          callback([]);
           return;
         }
 
         const lineText = line.translateToString(true);
-        const links: ILink[] = [];
-
-        const addLink = (filePath: string, textStart: number): void => {
-          const file = app.vault.getFileByPath(filePath);
-          if (!file) {
-            return;
-          }
-          const startX = visualColumn(lineText, textStart) + 1;
-          const endX = visualColumn(lineText, textStart + filePath.length);
-          links.push({
-            range: {
-              end: { x: endX, y: bufferLineNumber },
-              start: { x: startX, y: bufferLineNumber },
-            },
-            text: filePath,
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            activate(_event: MouseEvent, _text: string): void {
-              app.workspace
-                .getLeaf(false)
-                .openFile(file)
-                .catch((error: unknown) => {
-                  activeSelf(terminal.element).console.error(error);
-                });
-            },
-          });
-        };
-
-        const parenRanges: { start: number; end: number }[] = [];
-        for (const match of lineText.matchAll(
-          VaultFileLinksAddon.#PAREN_REGEX,
-        )) {
-          if (match[1] !== undefined) {
-            addLink(match[1], match.index + 1); // +1 skips the opening `(`
-            parenRanges.push({
-              start: match.index + 1,
-              end: match.index + 1 + match[1].length,
-            });
-          }
-        }
-
-        for (const match of lineText.matchAll(
-          VaultFileLinksAddon.#BARE_REGEX,
-        )) {
-          if (match[1] !== undefined) {
-            const prefixLen = match[0].length - match[1].length;
-            const bareStart = match.index + prefixLen;
-            const bareEnd = bareStart + match[1].length;
-            if (
-              parenRanges.some((r) => bareStart >= r.start && bareEnd <= r.end)
-            ) {
-              continue;
-            }
-            addLink(match[1], bareStart);
-          }
-        }
-
-        callback(links.length > 0 ? links : undefined);
+        const { links: parenLinks, ranges: parenRanges } =
+          VaultFileLinksAddon.#processParenLinks(
+            lineText,
+            bufferLineNumber,
+            app,
+            terminal,
+          );
+        const bareLinks = VaultFileLinksAddon.#processBareLinks(
+          lineText,
+          bufferLineNumber,
+          app,
+          terminal,
+          parenRanges,
+        );
+        callback([...parenLinks, ...bareLinks]);
       },
     });
 
@@ -1164,16 +1121,104 @@ export class VaultFileLinksAddon implements ITerminalAddon {
   public dispose(): void {
     this.#disposer.call();
   }
-}
 
-// Converts a string character index to a 0-based visual terminal column,
-// counting double-width (CJK and ambiguous-width) characters as 2 columns.
-function visualColumn(text: string, charIndex: number): number {
-  let col = 0;
-  for (let i = 0; i < charIndex && i < text.length; ) {
-    const cp = text.codePointAt(i) ?? 0;
-    col += eastAsianWidth(cp, { ambiguousAsWide: true });
-    i += cp > 0xffff ? 2 : 1;
+  /** Converts a string character index to a 0-based visual terminal column,
+   * counting double-width (CJK and ambiguous-width) characters as 2 columns. */
+  static visualColumn(text: string, charIndex: number): number {
+    let col = 0;
+    for (let i = 0; i < charIndex && i < text.length; ) {
+      const cp = text.codePointAt(i) ?? 0;
+      col += eastAsianWidth(cp, { ambiguousAsWide: true });
+      i += cp > 0xffff ? 2 : 1;
+    }
+    return col;
   }
-  return col;
+
+  static makeLink(
+    lineText: string,
+    filePath: string,
+    textStart: number,
+    bufferLineNumber: number,
+    app: PluginContext["app"],
+    terminal: Terminal,
+  ): ILink | null {
+    const file = app.vault.getFileByPath(filePath);
+    if (!file) return null;
+    const startX = this.visualColumn(lineText, textStart) + 1;
+    const endX = this.visualColumn(lineText, textStart + filePath.length);
+    return {
+      range: {
+        end: { x: endX, y: bufferLineNumber },
+        start: { x: startX, y: bufferLineNumber },
+      },
+      text: filePath,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      activate(_event: MouseEvent, _text: string): void {
+        app.workspace
+          .getLeaf(false)
+          .openFile(file)
+          .catch((error: unknown) => {
+            activeSelf(terminal.element).console.error(error);
+          });
+      },
+    };
+  }
+
+  static #processParenLinks(
+    lineText: string,
+    bufferLineNumber: number,
+    app: PluginContext["app"],
+    terminal: Terminal,
+  ): {
+    links: readonly ILink[];
+    ranges: readonly { readonly start: number; readonly end: number }[];
+  } {
+    const links: ILink[] = [];
+    const ranges: { readonly start: number; readonly end: number }[] = [];
+    for (const match of lineText.matchAll(this.#PAREN_REGEX)) {
+      if (!match[1]) continue;
+      const link = this.makeLink(
+        lineText,
+        match[1],
+        match.index + 1,
+        bufferLineNumber,
+        app,
+        terminal,
+      );
+      if (link) links.push(link);
+      ranges.push({
+        start: match.index + 1,
+        end: match.index + 1 + match[1].length,
+      });
+    }
+    return { links, ranges };
+  }
+
+  static #processBareLinks(
+    lineText: string,
+    bufferLineNumber: number,
+    app: PluginContext["app"],
+    terminal: Terminal,
+    parenRanges: readonly { readonly start: number; readonly end: number }[],
+  ): readonly ILink[] {
+    const links: ILink[] = [];
+    for (const match of lineText.matchAll(this.#BARE_REGEX)) {
+      if (!match[1]) continue;
+      const prefixLen = match[0].length - match[1].length;
+      const bareStart = match.index + prefixLen;
+      const bareEnd = bareStart + match[1].length;
+      if (parenRanges.some((r) => bareStart >= r.start && bareEnd <= r.end))
+        continue;
+      const link = this.makeLink(
+        lineText,
+        match[1],
+        bareStart,
+        bufferLineNumber,
+        app,
+        terminal,
+      );
+      if (link) links.push(link);
+    }
+    return links;
+  }
 }

--- a/src/terminal/emulator-addons.ts
+++ b/src/terminal/emulator-addons.ts
@@ -1165,6 +1165,10 @@ function visualColumn(text: string, charIndex: number): number {
   return col;
 }
 
+// Best-effort East Asian Width classification for terminal column calculation.
+// Covers CJK, fullwidth forms, Hangul, wide emoji, and SMP ranges with
+// Unicode East Asian Width property W or F. Not exhaustive — terminals vary
+// in how they render certain characters (especially emoji).
 function isCjkDoubleWidth(cp: number): boolean {
   return (
     (cp >= 0x1100 && cp <= 0x115f) || // Hangul Jamo
@@ -1184,6 +1188,8 @@ function isCjkDoubleWidth(cp: number): boolean {
     (cp >= 0xffe0 && cp <= 0xffe6) || // Fullwidth Signs
     (cp >= 0x1b000 && cp <= 0x1b77f) || // Kana Supplement
     (cp >= 0x1f300 && cp <= 0x1f9ff) || // Misc Symbols & Pictographs
+    (cp >= 0x1fa00 && cp <= 0x1fa6f) || // Chess Symbols
+    (cp >= 0x1fa70 && cp <= 0x1faff) || // Symbols and Pictographs Extended-A
     (cp >= 0x20000 && cp <= 0x2a6df) || // CJK Extension B
     (cp >= 0x2a700 && cp <= 0x2ceaf) || // CJK Extension C/D/E
     (cp >= 0x2ceb0 && cp <= 0x2ebef) || // CJK Extension F

--- a/src/terminal/emulator-addons.ts
+++ b/src/terminal/emulator-addons.ts
@@ -1,3 +1,4 @@
+import { eastAsianWidth } from "get-east-asian-width";
 import {
   Functions,
   type PluginContext,
@@ -1159,40 +1160,8 @@ function visualColumn(text: string, charIndex: number): number {
   let col = 0;
   for (let i = 0; i < charIndex && i < text.length; ) {
     const cp = text.codePointAt(i) ?? 0;
-    col += isCjkDoubleWidth(cp) ? 2 : 1;
+    col += eastAsianWidth(cp, { ambiguousAsWide: true });
     i += cp > 0xffff ? 2 : 1;
   }
   return col;
-}
-
-// Best-effort East Asian Width classification for terminal column calculation.
-// Covers CJK, fullwidth forms, Hangul, wide emoji, and SMP ranges with
-// Unicode East Asian Width property W or F. Not exhaustive — terminals vary
-// in how they render certain characters (especially emoji).
-function isCjkDoubleWidth(cp: number): boolean {
-  return (
-    (cp >= 0x1100 && cp <= 0x115f) || // Hangul Jamo
-    cp === 0x2329 ||
-    cp === 0x232a ||
-    (cp >= 0x2e80 && cp <= 0x303e) || // CJK Radicals Supplement
-    (cp >= 0x3040 && cp <= 0x33ff) || // Japanese kana + CJK compat
-    (cp >= 0x3400 && cp <= 0x4dbf) || // CJK Extension A
-    (cp >= 0x4e00 && cp <= 0xa4cf) || // CJK Unified + Yi
-    (cp >= 0xa960 && cp <= 0xa97f) || // Hangul Jamo Extended-A
-    (cp >= 0xac00 && cp <= 0xd7af) || // Hangul Syllables
-    (cp >= 0xd7b0 && cp <= 0xd7ff) || // Hangul Jamo Extended-B
-    (cp >= 0xf900 && cp <= 0xfaff) || // CJK Compatibility Ideographs
-    (cp >= 0xfe10 && cp <= 0xfe19) || // Vertical Forms
-    (cp >= 0xfe30 && cp <= 0xfe6f) || // CJK Compatibility Forms
-    (cp >= 0xff00 && cp <= 0xff60) || // Fullwidth Latin + Halfwidth Katakana
-    (cp >= 0xffe0 && cp <= 0xffe6) || // Fullwidth Signs
-    (cp >= 0x1b000 && cp <= 0x1b77f) || // Kana Supplement
-    (cp >= 0x1f300 && cp <= 0x1f9ff) || // Misc Symbols & Pictographs
-    (cp >= 0x1fa00 && cp <= 0x1fa6f) || // Chess Symbols
-    (cp >= 0x1fa70 && cp <= 0x1faff) || // Symbols and Pictographs Extended-A
-    (cp >= 0x20000 && cp <= 0x2a6df) || // CJK Extension B
-    (cp >= 0x2a700 && cp <= 0x2ceaf) || // CJK Extension C/D/E
-    (cp >= 0x2ceb0 && cp <= 0x2ebef) || // CJK Extension F
-    (cp >= 0x30000 && cp <= 0x3134f) // CJK Extension G
-  );
 }

--- a/src/terminal/emulator-addons.ts
+++ b/src/terminal/emulator-addons.ts
@@ -11,7 +11,7 @@ import {
 } from "@polyipseity/obsidian-plugin-library";
 import type { CanvasAddon } from "@xterm/addon-canvas";
 import type { WebglAddon } from "@xterm/addon-webgl";
-import type { ITerminalAddon, ITheme, Terminal } from "@xterm/xterm";
+import type { ILink, ITerminalAddon, ITheme, Terminal } from "@xterm/xterm";
 import { constant, isUndefined } from "lodash-es";
 import { around } from "monkey-around";
 import { noop } from "ts-essentials";
@@ -1057,4 +1057,139 @@ export class SynchronizedOutputScrollAddon implements ITerminalAddon {
   public dispose(): void {
     this.#disposer.call();
   }
+}
+
+// Detects vault-relative .md file paths in the terminal and opens them in
+// Obsidian's viewer on click, instead of the system default application.
+//
+// Supports two path formats that appear in terminal output:
+//   1. Parenthesized (may contain spaces): (wiki/goals/My File.md)
+//   2. Bare paths (no spaces):             wiki/some/file.md
+export class VaultFileLinksAddon implements ITerminalAddon {
+  readonly #disposer = new Functions({ async: false, settled: true });
+
+  // Parenthesized paths: (path/to/file.md) — spaces inside are allowed
+  static readonly #PAREN_REGEX = /\(([^)\n]+\.md)\)/g;
+
+  // Bare space-free paths: path/to/file.md
+  static readonly #BARE_REGEX =
+    /(?:^|[\s"'])([^\s"'()[\]{}<>|\\:]+\.md)(?=[\s"'()[\]{}<>|\\:,;]|$)/gm;
+
+  public constructor(protected readonly context: PluginContext) {}
+
+  public activate(terminal: Terminal): void {
+    const {
+      context: { app },
+    } = this;
+
+    const disposable = terminal.registerLinkProvider({
+      provideLinks(
+        bufferLineNumber: number,
+        callback: (links: ILink[] | undefined) => void,
+      ): void {
+        // getLine uses 0-based index; bufferLineNumber is 1-based
+        const line = terminal.buffer.active.getLine(bufferLineNumber - 1);
+        if (!line) {
+          callback(undefined);
+          return;
+        }
+
+        const lineText = line.translateToString(true);
+        const links: ILink[] = [];
+
+        const addLink = (filePath: string, textStart: number): void => {
+          const file = app.vault.getFileByPath(filePath);
+          if (!file) {
+            return;
+          }
+          const startX = visualColumn(lineText, textStart) + 1;
+          const endX = visualColumn(lineText, textStart + filePath.length);
+          links.push({
+            range: {
+              end: { x: endX, y: bufferLineNumber },
+              start: { x: startX, y: bufferLineNumber },
+            },
+            text: filePath,
+            activate(_event: MouseEvent, text: string): void {
+              const vaultFile = app.vault.getFileByPath(text);
+              if (!vaultFile) {
+                return;
+              }
+              app.workspace
+                .getLeaf(false)
+                .openFile(vaultFile)
+                .catch((error: unknown) => {
+                  activeSelf(terminal.element).console.error(error);
+                });
+            },
+          });
+        };
+
+        for (const match of lineText.matchAll(
+          VaultFileLinksAddon.#PAREN_REGEX,
+        )) {
+          if (match[1] !== undefined && match.index !== undefined) {
+            addLink(match[1], match.index + 1); // +1 skips the opening `(`
+          }
+        }
+
+        for (const match of lineText.matchAll(
+          VaultFileLinksAddon.#BARE_REGEX,
+        )) {
+          if (match[1] !== undefined && match.index !== undefined) {
+            const prefixLen = match[0].length - match[1].length;
+            addLink(match[1], match.index + prefixLen);
+          }
+        }
+
+        callback(links.length > 0 ? links : undefined);
+      },
+    });
+
+    this.#disposer.push(() => {
+      disposable.dispose();
+    });
+  }
+
+  public dispose(): void {
+    this.#disposer.call();
+  }
+}
+
+// Converts a string character index to a 0-based visual terminal column,
+// counting double-width CJK characters as 2 columns.
+function visualColumn(text: string, charIndex: number): number {
+  let col = 0;
+  for (let i = 0; i < charIndex && i < text.length; ) {
+    const cp = text.codePointAt(i) ?? 0;
+    col += isCjkDoubleWidth(cp) ? 2 : 1;
+    i += cp > 0xffff ? 2 : 1;
+  }
+  return col;
+}
+
+function isCjkDoubleWidth(cp: number): boolean {
+  return (
+    (cp >= 0x1100 && cp <= 0x115f) || // Hangul Jamo
+    cp === 0x2329 ||
+    cp === 0x232a ||
+    (cp >= 0x2e80 && cp <= 0x303e) || // CJK Radicals Supplement
+    (cp >= 0x3040 && cp <= 0x33ff) || // Japanese kana + CJK compat
+    (cp >= 0x3400 && cp <= 0x4dbf) || // CJK Extension A
+    (cp >= 0x4e00 && cp <= 0xa4cf) || // CJK Unified + Yi
+    (cp >= 0xa960 && cp <= 0xa97f) || // Hangul Jamo Extended-A
+    (cp >= 0xac00 && cp <= 0xd7af) || // Hangul Syllables
+    (cp >= 0xd7b0 && cp <= 0xd7ff) || // Hangul Jamo Extended-B
+    (cp >= 0xf900 && cp <= 0xfaff) || // CJK Compatibility Ideographs
+    (cp >= 0xfe10 && cp <= 0xfe19) || // Vertical Forms
+    (cp >= 0xfe30 && cp <= 0xfe6f) || // CJK Compatibility Forms
+    (cp >= 0xff00 && cp <= 0xff60) || // Fullwidth Latin + Halfwidth Katakana
+    (cp >= 0xffe0 && cp <= 0xffe6) || // Fullwidth Signs
+    (cp >= 0x1b000 && cp <= 0x1b77f) || // Kana Supplement
+    (cp >= 0x1f300 && cp <= 0x1f9ff) || // Misc Symbols & Pictographs
+    (cp >= 0x20000 && cp <= 0x2a6df) || // CJK Extension B
+    (cp >= 0x2a700 && cp <= 0x2ceaf) || // CJK Extension C/D/E
+    (cp >= 0x2ceb0 && cp <= 0x2ebef) || // CJK Extension F
+    (cp >= 0x30000 && cp <= 0x3134f) // CJK Extension G
+  );
 }

--- a/src/terminal/emulator-addons.ts
+++ b/src/terminal/emulator-addons.ts
@@ -1126,7 +1126,7 @@ export class VaultFileLinksAddon implements ITerminalAddon {
         for (const match of lineText.matchAll(
           VaultFileLinksAddon.#PAREN_REGEX,
         )) {
-          if (match[1] !== undefined && match.index !== undefined) {
+          if (match[1] !== undefined) {
             addLink(match[1], match.index + 1); // +1 skips the opening `(`
           }
         }
@@ -1134,7 +1134,7 @@ export class VaultFileLinksAddon implements ITerminalAddon {
         for (const match of lineText.matchAll(
           VaultFileLinksAddon.#BARE_REGEX,
         )) {
-          if (match[1] !== undefined && match.index !== undefined) {
+          if (match[1] !== undefined) {
             const prefixLen = match[0].length - match[1].length;
             addLink(match[1], match.index + prefixLen);
           }
@@ -1155,7 +1155,7 @@ export class VaultFileLinksAddon implements ITerminalAddon {
 }
 
 // Converts a string character index to a 0-based visual terminal column,
-// counting double-width CJK characters as 2 columns.
+// counting double-width (CJK and ambiguous-width) characters as 2 columns.
 function visualColumn(text: string, charIndex: number): number {
   let col = 0;
   for (let i = 0; i < charIndex && i < text.length; ) {

--- a/src/terminal/view.ts
+++ b/src/terminal/view.ts
@@ -73,6 +73,7 @@ import {
   RendererAddon,
   RightClickActionAddon,
   SynchronizedOutputScrollAddon,
+  VaultFileLinksAddon,
 } from "./emulator-addons.js";
 import { XtermTerminalEmulator } from "./emulator.js";
 import {
@@ -1147,6 +1148,7 @@ export class TerminalView extends ItemView {
                 ),
                 search: new SearchAddon(),
                 unicode11: new Unicode11Addon(),
+                vaultFileLinks: new VaultFileLinksAddon(context),
                 webLinks: new WebLinksAddon(
                   (event, uri) => openExternal(activeSelf(event), uri),
                   {
@@ -1340,6 +1342,7 @@ export namespace TerminalView {
     readonly search: SearchAddon;
     readonly synchronizedOutputScroll: SynchronizedOutputScrollAddon;
     readonly unicode11: Unicode11Addon;
+    readonly vaultFileLinks: VaultFileLinksAddon;
     readonly webLinks: WebLinksAddon;
   }
   export interface State {

--- a/tests/src/terminal/emulator-addons.spec.ts
+++ b/tests/src/terminal/emulator-addons.spec.ts
@@ -820,4 +820,46 @@ describe("VaultFileLinksAddon", () => {
     addon.dispose();
     expect(disposer.dispose).toHaveBeenCalled();
   });
+
+  // --- Link range x-coordinates ---
+
+  it("computes correct x-range for link at line start", () => {
+    const { provideLinks } = createBed();
+    const links = provideLinks("(file.md)");
+    expect(links).toHaveLength(1);
+    // `(` is column 1, `f` starts at column 2.
+    expect(links?.[0]?.range.start.x).toBe(2);
+    // `(` + `file.md` = 8 visual columns (all ASCII).
+    expect(links?.[0]?.range.end.x).toBe(8);
+  });
+
+  it("computes correct x-range for link after ASCII text", () => {
+    const { provideLinks } = createBed();
+    const links = provideLinks("see (file.md) here");
+    expect(links).toHaveLength(1);
+    // `see ` is 4 columns, `(` is column 5, `f` starts at column 6.
+    expect(links?.[0]?.range.start.x).toBe(6);
+    // `see (file.md` = 12 visual columns (all ASCII).
+    expect(links?.[0]?.range.end.x).toBe(12);
+  });
+
+  it("accounts for double-width characters in x-range", () => {
+    const { provideLinks } = createBed();
+    const links = provideLinks("中文(content.md)");
+    expect(links).toHaveLength(1);
+    // `中` = 2 columns, `文` = 2 columns, `(` = 1 column → `f` at column 6.
+    expect(links?.[0]?.range.start.x).toBe(6);
+    // `content.md` = 10 chars, all ASCII, adds 10 columns past `(`.
+    expect(links?.[0]?.range.end.x).toBe(15);
+  });
+
+  it("x-range end minus start plus one equals path visual length", () => {
+    const { provideLinks } = createBed();
+    const links = provideLinks("(abc.md)");
+    expect(links).toHaveLength(1);
+    // "abc.md" is 6 ASCII chars, each 1 column wide.
+    expect(
+      (links?.[0]?.range.end.x ?? 0) - (links?.[0]?.range.start.x ?? 0) + 1,
+    ).toBe(6);
+  });
 });

--- a/tests/src/terminal/emulator-addons.spec.ts
+++ b/tests/src/terminal/emulator-addons.spec.ts
@@ -664,7 +664,7 @@ describe("VaultFileLinksAddon", () => {
   it("ignores parenthesized text without .md extension", () => {
     const { provideLinks } = createBed();
     const links = provideLinks("(test.txt)");
-    expect(links).toBeUndefined();
+    expect(links).toHaveLength(0);
   });
 
   // --- Bare links ---
@@ -721,16 +721,16 @@ describe("VaultFileLinksAddon", () => {
 
   // --- No-match cases ---
 
-  it("returns undefined for a line with no .md links", () => {
+  it("returns empty array for a line with no .md links", () => {
     const { provideLinks } = createBed();
     const links = provideLinks("Just some plain text");
-    expect(links).toBeUndefined();
+    expect(links).toHaveLength(0);
   });
 
-  it("returns undefined for empty line", () => {
+  it("returns empty array for empty line", () => {
     const { provideLinks } = createBed();
     const links = provideLinks("");
-    expect(links).toBeUndefined();
+    expect(links).toHaveLength(0);
   });
 
   // --- File resolution ---
@@ -746,7 +746,7 @@ describe("VaultFileLinksAddon", () => {
   it("omits links whose files do not exist", () => {
     const { provideLinks } = createBed(false);
     const links = provideLinks("(test.md)");
-    expect(links).toBeUndefined();
+    expect(links).toHaveLength(0);
   });
 
   // --- Activation ---

--- a/tests/src/terminal/emulator-addons.spec.ts
+++ b/tests/src/terminal/emulator-addons.spec.ts
@@ -646,13 +646,17 @@ describe("VaultFileLinksAddon", () => {
   });
 
   it("finds parenthesized .md links with spaces", () => {
-    const { provideLinks, getFileByPath } = createBed();
-    // The bare regex also matches "notes/file.md" from inside the parens,
-    // but only the full parenthesized path exists in the vault.
-    getFileByPath.mockImplementation((path: string) => {
-      return path === "my notes/file.md" ? MOCK_FILE : null;
-    });
+    const { provideLinks } = createBed();
     const links = provideLinks("Open (my notes/file.md) here");
+    expect(links).toHaveLength(1);
+    expect(links?.[0]?.text).toBe("my notes/file.md");
+  });
+
+  it("filters bare sub-matches inside parenthesized paths", () => {
+    const { provideLinks } = createBed();
+    // The bare regex would match "notes/file.md" as a sub-path, but it falls
+    // inside paren range of "my notes/file.md", so only 1 link is produced.
+    const links = provideLinks("(my notes/file.md)");
     expect(links).toHaveLength(1);
     expect(links?.[0]?.text).toBe("my notes/file.md");
   });

--- a/tests/src/terminal/emulator-addons.spec.ts
+++ b/tests/src/terminal/emulator-addons.spec.ts
@@ -11,13 +11,16 @@
  * - SynchronizedOutputScrollAddon: scroll position preservation across DEC 2026
  *   synchronized output blocks via queueMicrotask (xterm.js issue #5801 workaround)
  */
-import type { IDisposable, Terminal } from "@xterm/xterm";
+import type { ILink, ILinkProvider, IDisposable, Terminal } from "@xterm/xterm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { App, TFile, Vault, Workspace, WorkspaceLeaf } from "obsidian";
+import type { PluginContext } from "@polyipseity/obsidian-plugin-library";
 import type { Settings } from "../../../src/settings-data.js";
 import {
   CustomKeyEventHandlerAddon,
   FollowThemeAddon,
   SynchronizedOutputScrollAddon,
+  VaultFileLinksAddon,
 } from "../../../src/terminal/emulator-addons.js";
 
 /** Minimal mock Terminal with `input()` and `attachCustomKeyEventHandler()`. */
@@ -557,5 +560,260 @@ describe("SynchronizedOutputScrollAddon", () => {
       returnVals.push(h(fakeParams));
     }
     expect(returnVals).toEqual([false, false]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// VaultFileLinksAddon
+// ---------------------------------------------------------------------------
+
+describe("VaultFileLinksAddon", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /** Mock file returned by getFileByPath. */
+  const MOCK_FILE = { path: "test.md", name: "test.md" } as TFile;
+
+  /**
+   * Creates a VaultFileLinksAddon test bed.
+   *
+   * @param fileExists - Whether getFileByPath should return a TFile or null.
+   */
+  function createBed(fileExists = true): {
+    provideLinks(lineText: string): ILink[] | undefined;
+    getFileByPath: ReturnType<typeof vi.fn>;
+    openFile: ReturnType<typeof vi.fn>;
+    getLeaf: ReturnType<typeof vi.fn>;
+    disposable: IDisposable;
+    addon: VaultFileLinksAddon;
+  } {
+    const getFileByPath = vi.fn(() => (fileExists ? MOCK_FILE : null));
+    const vault = { getFileByPath } as unknown as Vault;
+
+    const openFile = vi.fn().mockResolvedValue(undefined);
+    const getLeaf = vi.fn(() => ({ openFile }) as unknown as WorkspaceLeaf);
+    const workspace = { getLeaf } as unknown as Workspace;
+
+    const app = { vault, workspace } as unknown as App;
+    const context = { app } as unknown as PluginContext;
+
+    const addon = new VaultFileLinksAddon(context);
+
+    let capturedProvider: ILinkProvider | undefined;
+    const disposable = { dispose: vi.fn() };
+    const registerLinkProvider = vi.fn((p: ILinkProvider) => {
+      capturedProvider = p;
+      return disposable;
+    });
+
+    const getLine = vi.fn();
+    const terminal = {
+      registerLinkProvider,
+      buffer: { active: { getLine } },
+      element: document.createElement("div"),
+    } as unknown as Terminal;
+
+    addon.activate(terminal);
+
+    function provideLinks(lineText: string): ILink[] | undefined {
+      let result: ILink[] | undefined;
+      const line = { translateToString: vi.fn(() => lineText) };
+      getLine.mockReturnValue(line);
+      capturedProvider?.provideLinks(1, (links) => {
+        result = links;
+      });
+      return result;
+    }
+
+    return {
+      provideLinks,
+      getFileByPath,
+      openFile,
+      getLeaf,
+      disposable,
+      addon,
+    };
+  }
+
+  // --- Parenthesized links ---
+
+  it("finds parenthesized .md links", () => {
+    const { provideLinks } = createBed();
+    const links = provideLinks("See (test.md) for details");
+    expect(links).toHaveLength(1);
+    expect(links?.[0]?.text).toBe("test.md");
+  });
+
+  it("finds parenthesized .md links with spaces", () => {
+    const { provideLinks, getFileByPath } = createBed();
+    // The bare regex also matches "notes/file.md" from inside the parens,
+    // but only the full parenthesized path exists in the vault.
+    getFileByPath.mockImplementation((path: string) => {
+      return path === "my notes/file.md" ? MOCK_FILE : null;
+    });
+    const links = provideLinks("Open (my notes/file.md) here");
+    expect(links).toHaveLength(1);
+    expect(links?.[0]?.text).toBe("my notes/file.md");
+  });
+
+  it("ignores parenthesized text without .md extension", () => {
+    const { provideLinks } = createBed();
+    const links = provideLinks("(test.txt)");
+    expect(links).toBeUndefined();
+  });
+
+  // --- Bare links ---
+
+  it("finds bare .md links after whitespace", () => {
+    const { provideLinks } = createBed();
+    const links = provideLinks("see docs/file.md for info");
+    expect(links).toHaveLength(1);
+    expect(links?.[0]?.text).toBe("docs/file.md");
+  });
+
+  it("finds bare .md links at line start", () => {
+    const { provideLinks } = createBed();
+    const links = provideLinks("file.md is here");
+    expect(links).toHaveLength(1);
+    expect(links?.[0]?.text).toBe("file.md");
+  });
+
+  it("finds bare .md links after an opening quote", () => {
+    const { provideLinks } = createBed();
+    const links = provideLinks('read "docs/file.md" here');
+    expect(links).toHaveLength(1);
+    expect(links?.[0]?.text).toBe("docs/file.md");
+  });
+
+  it("does not include preceding space or quote in link text", () => {
+    const { provideLinks } = createBed();
+    const withSpace = provideLinks("see docs/file.md now");
+    expect(withSpace).toHaveLength(1);
+    expect(withSpace?.[0]?.text).toBe("docs/file.md");
+
+    const withQuote = provideLinks('"docs/file.md"');
+    expect(withQuote).toHaveLength(1);
+    expect(withQuote?.[0]?.text).toBe("docs/file.md");
+  });
+
+  // --- Multiple links ---
+
+  it("finds multiple parenthesized links on one line", () => {
+    const { provideLinks } = createBed();
+    const links = provideLinks("(a.md) and (b.md)");
+    expect(links).toHaveLength(2);
+    expect(links?.[0]?.text).toBe("a.md");
+    expect(links?.[1]?.text).toBe("b.md");
+  });
+
+  it("finds mixed bare and parenthesized links", () => {
+    const { provideLinks } = createBed();
+    const links = provideLinks("(a.md) and b.md");
+    expect(links).toHaveLength(2);
+    expect(links?.[0]?.text).toBe("a.md");
+    expect(links?.[1]?.text).toBe("b.md");
+  });
+
+  // --- No-match cases ---
+
+  it("returns undefined for a line with no .md links", () => {
+    const { provideLinks } = createBed();
+    const links = provideLinks("Just some plain text");
+    expect(links).toBeUndefined();
+  });
+
+  it("returns undefined for empty line", () => {
+    const { provideLinks } = createBed();
+    const links = provideLinks("");
+    expect(links).toBeUndefined();
+  });
+
+  // --- File resolution ---
+
+  it("calls getFileByPath for each matched link", () => {
+    const { provideLinks, getFileByPath } = createBed();
+    provideLinks("(a.md) and (b.md)");
+    expect(getFileByPath).toHaveBeenCalledTimes(2);
+    expect(getFileByPath).toHaveBeenCalledWith("a.md");
+    expect(getFileByPath).toHaveBeenCalledWith("b.md");
+  });
+
+  it("omits links whose files do not exist", () => {
+    const { provideLinks } = createBed(false);
+    const links = provideLinks("(test.md)");
+    expect(links).toBeUndefined();
+  });
+
+  // --- Activation ---
+
+  it("activates by opening the file in Obsidian", () => {
+    const { provideLinks, openFile, getLeaf } = createBed();
+    const links = provideLinks("(test.md)");
+    expect(links).toHaveLength(1);
+
+    links?.[0]?.activate({} as MouseEvent, "test.md");
+    expect(getLeaf).toHaveBeenCalledWith(false);
+    expect(openFile).toHaveBeenCalledWith(MOCK_FILE);
+  });
+
+  it("logs to console.error when openFile rejects", async () => {
+    const getFileByPath = vi.fn(() => MOCK_FILE);
+    const vault = { getFileByPath } as unknown as Vault;
+
+    const consoleError = vi.fn();
+    vi.spyOn(console, "error").mockImplementation(consoleError);
+
+    const openFile = vi.fn().mockRejectedValue(new Error("fail"));
+    const getLeaf = vi.fn(() => ({ openFile }) as unknown as WorkspaceLeaf);
+    const workspace = { getLeaf } as unknown as Workspace;
+    const app = { vault, workspace } as unknown as App;
+    const context = { app } as unknown as PluginContext;
+    const addon = new VaultFileLinksAddon(context);
+
+    let capturedProvider: ILinkProvider;
+    const terminal = {
+      registerLinkProvider: vi.fn((p: ILinkProvider) => {
+        capturedProvider = p;
+        return { dispose: vi.fn() };
+      }),
+      buffer: { active: { getLine: vi.fn() } },
+      element: document.createElement("div"),
+    } as unknown as Terminal;
+    addon.activate(terminal);
+
+    const line = { translateToString: vi.fn(() => "(test.md)") };
+    terminal.buffer.active.getLine.mockReturnValue(line);
+    let result: ILink[] | undefined;
+    capturedProvider?.provideLinks(1, (links) => {
+      result = links;
+    });
+
+    result?.[0]?.activate({} as MouseEvent, "test.md");
+
+    await Promise.resolve();
+    expect(consoleError).toHaveBeenCalled();
+  });
+
+  // --- Disposal ---
+
+  it("dispose() disposes the registered link provider", () => {
+    const disposer = { dispose: vi.fn() };
+    const registerLinkProvider = vi.fn(() => disposer);
+    const terminal = {
+      registerLinkProvider,
+      buffer: { active: { getLine: vi.fn() } },
+      element: document.createElement("div"),
+    } as unknown as Terminal;
+
+    const getFileByPath = vi.fn();
+    const vault = { getFileByPath } as unknown as Vault;
+    const app = { vault, workspace: {} as Workspace } as unknown as App;
+    const context = { app } as unknown as PluginContext;
+    const addon = new VaultFileLinksAddon(context);
+    addon.activate(terminal);
+
+    addon.dispose();
+    expect(disposer.dispose).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Adds `VaultFileLinksAddon` in `emulator-addons.ts` that registers a custom xterm.js link provider
- Detects vault-relative Markdown paths in terminal output and makes them clickable
- On click, opens the file in Obsidian's viewer via `app.workspace.getLeaf().openFile()`

## Behavior

Recognizes two path formats:

| Format | Example |
|---|---|
| Parenthesized (spaces allowed) | `(wiki/goals/My File.md)` |
| Bare path (no spaces) | `wiki/some/file.md` |

Only paths that resolve to an existing vault file produce a clickable link — no false positives for arbitrary `.md` strings.

CJK double-width characters (Korean, Japanese, Chinese) are accounted for in the xterm.js column range calculation.

## Use case

When a tool like Claude Code outputs file paths in the terminal (e.g., `(wiki/youtubers/someChannel/index.md)`), clicking the path opens it directly in Obsidian's Markdown viewer instead of the system default text editor.

## Test plan

- [ ] Click a vault-relative `.md` path in the terminal → file opens in Obsidian viewer
- [ ] Parenthesized path with spaces works: `(wiki/goals/My File.md)`
- [ ] Path with Korean/CJK characters: `wiki/youtubers/하와이대저택/index.md`
- [ ] Non-existent path produces no clickable link
- [ ] Absolute paths (`/Users/...`) are not matched

🤖 Generated with [Claude Code](https://claude.com/claude-code)