### PR TITLE
fix(ci): repair main test and type-check failures

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -51,6 +51,8 @@ export default defineConfig([
         },
       ],
       "@typescript-eslint/no-namespace": "off",
+      // The TypeScript compiler already reports undefined identifiers; core `no-undef` false-positives on type-only globals such as the `NodeJS` namespace and Electron's renderer `require`.
+      "no-undef": "off",
       "@typescript-eslint/no-unused-vars": [
         "error",
         {
@@ -75,6 +77,17 @@ export default defineConfig([
       "obsidianmd/no-nodejs-modules": "off",
       "obsidianmd/prefer-create-el": "off",
       "obsidianmd/rule-custom-message": "off",
+    },
+  },
+  // Desktop-only integrated-terminal modules import Node builtins as types only (erased at compile time); runtime Node access goes through guarded dynamic requires
+  {
+    files: [
+      "src/terminal/emulator.ts",
+      "src/terminal/pseudoterminal.ts",
+      "src/utils.ts",
+    ],
+    rules: {
+      "obsidianmd/no-nodejs-modules": "off",
     },
   },
   // JSON files are data declarations, not executable code — expression and UI-text rules don't apply

--- a/src/@types/obsidian.ts
+++ b/src/@types/obsidian.ts
@@ -4,7 +4,7 @@ declare module "obsidian" {
   }
 
   interface App extends Private<$App, PrivateKey> {}
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- `T` must stay declared to match the augmented class signature.
   interface SuggestModal<T> extends Private<$SuggestModal, PrivateKey> {}
 }
 import type { Private } from "@polyipseity/obsidian-plugin-library";

--- a/src/imports.ts
+++ b/src/imports.ts
@@ -1,7 +1,7 @@
-/* eslint-disable @typescript-eslint/no-require-imports */
 import { deepFreeze, typedKeys } from "@polyipseity/obsidian-plugin-library";
 
 // Needed for bundler
+/* eslint-disable @typescript-eslint/no-require-imports -- The bundler rewrites these lazy `require()` calls; ESM imports would load the modules eagerly. */
 const BUNDLE0 = deepFreeze({
   "@xterm/addon-canvas": (): unknown => require("@xterm/addon-canvas"),
 
@@ -23,6 +23,7 @@ const BUNDLE0 = deepFreeze({
 
   "tmp-promise": (): unknown => require("tmp-promise"),
 });
+/* eslint-enable @typescript-eslint/no-require-imports -- End of the bundler-rewritten lazy `require()` map. */
 export const // Needed for bundler
   BUNDLE = new Map(Object.entries(BUNDLE0)),
   MODULES =

--- a/src/magic.ts
+++ b/src/magic.ts
@@ -1,6 +1,6 @@
 import { Platform, deepFreeze } from "@polyipseity/obsidian-plugin-library";
 import { SemVer } from "semver";
-import pythonRequirementsJson from "./python-requirements.json";
+import pythonRequirementsJson from "./python-requirements.json" with { type: "json" };
 
 export const CHECK_EXECUTABLE_WAIT = 5,
   DEFAULT_ENCODING = "utf-8",

--- a/src/modals.ts
+++ b/src/modals.ts
@@ -1,45 +1,45 @@
 import {
-    DISABLED_TOOLTIP,
-    DOMClasses,
-    EditDataModal,
-    ListModal,
-    Platform,
-    SI_PREFIX_SCALE,
-    type StatusUI,
-    UpdatableUI,
-    activeSelf,
-    anyToError,
-    assignExact,
-    clearProperties,
-    cloneAsWritable,
-    composeSetters,
-    consumeEvent,
-    createChildElement,
-    createDocumentFragment,
-    dynamicRequire,
-    escapeQuerySelectorAttribute,
-    inSet,
-    linkSetting,
-    notice2,
-    printError,
-    randomNotIn,
-    resetButton,
-    setTextToEnum,
-    setTextToNumber,
-    unexpected,
-    useSettings,
-    useSubsettings,
+  DISABLED_TOOLTIP,
+  DOMClasses,
+  EditDataModal,
+  ListModal,
+  Platform,
+  SI_PREFIX_SCALE,
+  type StatusUI,
+  UpdatableUI,
+  activeSelf,
+  anyToError,
+  assignExact,
+  clearProperties,
+  cloneAsWritable,
+  composeSetters,
+  consumeEvent,
+  createChildElement,
+  createDocumentFragment,
+  dynamicRequire,
+  escapeQuerySelectorAttribute,
+  inSet,
+  linkSetting,
+  notice2,
+  printError,
+  randomNotIn,
+  resetButton,
+  setTextToEnum,
+  setTextToNumber,
+  unexpected,
+  useSettings,
+  useSubsettings,
 } from "@polyipseity/obsidian-plugin-library";
-import { constant, identity, noop } from "lodash-es";
-import { Modal, Setting } from "obsidian";
+import { constant, identity, noop } from "es-toolkit/compat";
+import { Modal, Setting, sanitizeHTMLToDom } from "obsidian";
 import type { DeepWritable } from "ts-essentials";
 import { BUNDLE } from "./imports.js";
 import { CHECK_EXECUTABLE_WAIT, PYTHON_REQUIREMENTS } from "./magic.js";
 import { applyEnv } from "./terminal/environment.js";
 import {
-    DEFAULT_TERMINAL_OPTIONS,
-    PROFILE_PRESETS,
-    PROFILE_PRESET_ORDERED_KEYS,
+  DEFAULT_TERMINAL_OPTIONS,
+  PROFILE_PRESETS,
+  PROFILE_PRESET_ORDERED_KEYS,
 } from "./terminal/profile-presets.js";
 import { PROFILE_PROPERTIES } from "./terminal/profile-properties.js";
 import { Pseudoterminal } from "./terminal/pseudoterminal.js";
@@ -91,7 +91,11 @@ export class TerminalOptionsModal extends EditDataModal<Settings.Profile.Termina
     ui.new(
       () => createChildElement(element, "div"),
       (ele) => {
-        ele.innerHTML = i18n.t("components.terminal-options.description-HTML");
+        ele.replaceChildren(
+          sanitizeHTMLToDom(
+            i18n.t("components.terminal-options.description-HTML"),
+          ),
+        );
       },
       (ele) => {
         ele.remove();
@@ -725,8 +729,12 @@ export class ProfileModal extends Modal {
           .setDesc(
             createDocumentFragment(settingEl.ownerDocument, (frag) => {
               createChildElement(frag, "span", (ele) => {
-                ele.innerHTML = i18n.t(
-                  "components.profile.restore-history-description-HTML",
+                ele.replaceChildren(
+                  sanitizeHTMLToDom(
+                    i18n.t(
+                      "components.profile.restore-history-description-HTML",
+                    ),
+                  ),
                 );
               });
             }),
@@ -778,7 +786,7 @@ export class ProfileModal extends Modal {
                   profile.successExitCodes,
                   {
                     callback: async (value): Promise<void> => {
-                      profile.successExitCodes = value;
+                      profile.successExitCodes = [...value];
                       await this.postMutate();
                     },
                     title: (): string =>
@@ -867,7 +875,7 @@ export class ProfileModal extends Modal {
                     profile.args,
                     {
                       callback: async (value): Promise<void> => {
-                        profile.args = value;
+                        profile.args = [...value];
                         await this.postMutate();
                       },
                       title: (): string =>
@@ -926,7 +934,7 @@ export class ProfileModal extends Modal {
                           )
                           .setDisabled(!editable);
                         if (!refs) {
-                          textArea.inputEl.style.visibility = "hidden";
+                          textArea.inputEl.classList.add("terminal:hidden");
                           return;
                         }
                         textArea
@@ -946,7 +954,7 @@ export class ProfileModal extends Modal {
                           )
                           .setDisabled(!editable);
                         if (!refs) {
-                          textArea.inputEl.style.visibility = "hidden";
+                          textArea.inputEl.classList.add("terminal:hidden");
                           return;
                         }
                         textArea
@@ -962,7 +970,7 @@ export class ProfileModal extends Modal {
                     profile.environment,
                     {
                       callback: async (value): Promise<void> => {
-                        profile.environment = value;
+                        profile.environment = value.map(([k, v]) => [k, v]);
                         await this.postMutate();
                       },
                       description: (): string =>
@@ -1090,7 +1098,7 @@ export class ProfileModal extends Modal {
                       return;
                     }
                     checkingPython = true;
-                    (async (): Promise<void> => {
+                    void (async (): Promise<void> => {
                       try {
                         const [execFileP2, getPackageVersion2] =
                             await Promise.all([execFileP, getPackageVersion]),
@@ -1278,7 +1286,7 @@ export class ProfileListModal extends ListModal<
             .setTooltip(i18n.t("components.profile-list.mark-as-default"))
             .setDisabled(!editable);
           if (!refs) {
-            button.buttonEl.style.visibility = "hidden";
+            button.buttonEl.classList.add("terminal:hidden");
             return;
           }
           if (
@@ -1308,7 +1316,7 @@ export class ProfileListModal extends ListModal<
             .setTooltip(i18n.t("components.profile-list.edit"))
             .setDisabled(!editable);
           if (!refs) {
-            button.buttonEl.style.visibility = "hidden";
+            button.buttonEl.classList.add("terminal:hidden");
             return;
           }
           button.onClick(() => {
@@ -1456,7 +1464,7 @@ export class KeymappingEditModal extends Modal {
         data.alt = event.altKey;
         data.meta = event.metaKey;
         data.shift = event.shiftKey;
-        (async () => {
+        void (async () => {
           try {
             await this.postMutate();
           } catch (error) {
@@ -1518,7 +1526,7 @@ export class KeymappingEditModal extends Modal {
                 this.#stopRecording();
                 return;
               }
-              startRecording();
+              void startRecording();
             });
           if (isRecording) {
             button.setCta();
@@ -1701,7 +1709,7 @@ export class KeymappingsModal extends ListModal<
             .setTooltip(i18n.t("components.keymappings.edit"))
             .setDisabled(!editable);
           if (!refs) {
-            button.buttonEl.style.visibility = "hidden";
+            button.buttonEl.classList.add("terminal:hidden");
             return;
           }
           button.onClick(() => {

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -10,7 +10,7 @@ import {
 import type { App } from "obsidian";
 import type { TerminalPlugin } from "./main.js";
 import { around } from "monkey-around";
-import { noop } from "lodash-es";
+import { noop } from "es-toolkit/compat";
 
 export class Log {
   public readonly logger = new EventEmitterLite<readonly [Log.Event]>();
@@ -148,7 +148,7 @@ function patchLoggingWindow(self0: Window, log: Log): () => void {
   }
 }
 
-function patchLogging(self0: Window & typeof globalThis, log: Log): () => void {
+function patchLogging(self0: Window & typeof window, log: Log): () => void {
   const ret = new Functions({ async: false, settled: true });
   try {
     ret.push(patchLoggingConsole(self0.console, log));
@@ -246,7 +246,7 @@ export class EarlyPatchManager extends ResourceComponent<EarlyPatch> {
 
 function patchRequire(
   context: TerminalPlugin,
-  self0: typeof globalThis,
+  self0: typeof window,
 ): () => void {
   const { settings } = context;
   return around(self0, {

--- a/src/settings-data.ts
+++ b/src/settings-data.ts
@@ -24,12 +24,13 @@ import type {
   FontWeight,
   ILinkHandler,
   ILogger,
+  IOverviewRulerOptions,
   ITerminalOptions,
   ITheme,
   IWindowOptions,
   IWindowsPty,
 } from "@xterm/xterm";
-import { isNil, isUndefined, omitBy } from "lodash-es";
+import { isUndefined, omitBy } from "es-toolkit/compat";
 import type {
   DeepReadonly,
   DeepRequired,
@@ -46,6 +47,7 @@ import {
 import {
   DEFAULT_LINK_HANDLER,
   DEFAULT_LOGGER,
+  DEFAULT_OVERVIEW_RULER,
   DEFAULT_TERMINAL_OPTIONS,
   DEFAULT_THEME,
   DEFAULT_WINDOWS_PTY,
@@ -53,6 +55,17 @@ import {
   PROFILE_PRESETS,
 } from "./terminal/profile-presets.js";
 import { Pseudoterminal } from "./terminal/pseudoterminal.js";
+
+/**
+ * Every key of `T` present, each value possibly `undefined`.
+ *
+ * `Required<DeepUndefinable<T>>` strips `undefined` from optional properties.
+ * Mapping over `keyof Required<T>` is non-homomorphic, so no modifier-based
+ * `undefined` filtering applies and fixer results stay assignable.
+ */
+type CompleteUndefinable<T> = {
+  readonly [K in keyof Required<T>]: DeepUndefinable<T[K]> | undefined;
+};
 
 export interface LocalSettings extends PluginContext.LocalSettings {
   readonly lastReadChangelogVersion: SemVerString;
@@ -391,10 +404,7 @@ export namespace Settings {
   } & (
     | {
         readonly action:
-          | "ignore"
-          | "passthrough"
-          | "scrollToBottom"
-          | "scrollToTop";
+          "ignore" | "passthrough" | "scrollToBottom" | "scrollToTop";
         readonly actionArg: null;
       }
     | {
@@ -700,22 +710,21 @@ export namespace Settings {
      *  Each element must be a two-element `[string, string]` array; invalid
      *  elements are silently dropped rather than falling the whole array back
      *  to the default. */
-    function fixEnvironment(
-      val: unknown,
-    ): readonly (readonly [string, string])[] {
+    function fixEnvironment(val: unknown): [string, string][] {
       if (!Array.isArray(val)) {
         return [];
       }
-      const result: (readonly [string, string])[] = [];
-      for (const entry of val) {
+      const result: [string, string][] = [];
+      for (const entry of val as readonly unknown[]) {
         if (!Array.isArray(entry)) {
           continue;
         }
-        const [k, v] = entry;
+        const pair: readonly unknown[] = entry,
+          [k, v] = pair;
         if (typeof k !== "string" || typeof v !== "string") {
           continue;
         }
-        result.push([k, v] as const);
+        result.push([k, v]);
       }
       return result;
     }
@@ -749,148 +758,152 @@ export namespace Settings {
           const type = inSet(TYPES, unc.type) ? unc.type : "invalid";
           switch (type) {
             case "": {
+              const uncTyped: Unchecked<Typed<typeof type>> = unc;
               return {
-                followTheme: fixTyped(DEFAULTS[type], unc, "followTheme", [
+                followTheme: fixTyped(DEFAULTS[type], uncTyped, "followTheme", [
                   "boolean",
                 ]),
-                name: fixTyped(DEFAULTS[type], unc, "name", ["string"]),
+                name: fixTyped(DEFAULTS[type], uncTyped, "name", ["string"]),
                 restoreHistory: fixTyped(
                   DEFAULTS[type],
-                  unc,
+                  uncTyped,
                   "restoreHistory",
                   ["boolean"],
                 ),
                 rightClickAction: fixInSet(
                   DEFAULTS[type],
-                  unc,
+                  uncTyped,
                   "rightClickAction",
                   RightClickActionAddon.ACTIONS,
                 ),
                 successExitCodes: fixArray(
                   DEFAULTS[type],
-                  unc,
+                  uncTyped,
                   "successExitCodes",
                   ["string"],
                 ),
-                terminalOptions: fixTerminalOptions(unc["terminalOptions"])
+                terminalOptions: fixTerminalOptions(uncTyped["terminalOptions"])
                   .value,
                 type,
               } satisfies Typed<typeof type>;
             }
             case "developerConsole": {
+              const uncTyped: Unchecked<Typed<typeof type>> = unc;
               return {
-                followTheme: fixTyped(DEFAULTS[type], unc, "followTheme", [
+                followTheme: fixTyped(DEFAULTS[type], uncTyped, "followTheme", [
                   "boolean",
                 ]),
-                name: fixTyped(DEFAULTS[type], unc, "name", ["string"]),
+                name: fixTyped(DEFAULTS[type], uncTyped, "name", ["string"]),
                 restoreHistory: fixTyped(
                   DEFAULTS[type],
-                  unc,
+                  uncTyped,
                   "restoreHistory",
                   ["boolean"],
                 ),
                 rightClickAction: fixInSet(
                   DEFAULTS[type],
-                  unc,
+                  uncTyped,
                   "rightClickAction",
                   RightClickActionAddon.ACTIONS,
                 ),
                 successExitCodes: fixArray(
                   DEFAULTS[type],
-                  unc,
+                  uncTyped,
                   "successExitCodes",
                   ["string"],
                 ),
-                terminalOptions: fixTerminalOptions(unc["terminalOptions"])
+                terminalOptions: fixTerminalOptions(uncTyped["terminalOptions"])
                   .value,
                 type,
               } satisfies Typed<typeof type>;
             }
             case "external": {
+              const uncTyped: Unchecked<Typed<typeof type>> = unc;
               return {
-                args: fixArray(DEFAULTS[type], unc, "args", ["string"]),
-                environment: fixEnvironment(unc["environment"]),
-                executable: fixTyped(DEFAULTS[type], unc, "executable", [
+                args: fixArray(DEFAULTS[type], uncTyped, "args", ["string"]),
+                environment: fixEnvironment(uncTyped["environment"]),
+                executable: fixTyped(DEFAULTS[type], uncTyped, "executable", [
                   "string",
                 ]),
-                followTheme: fixTyped(DEFAULTS[type], unc, "followTheme", [
+                followTheme: fixTyped(DEFAULTS[type], uncTyped, "followTheme", [
                   "boolean",
                 ]),
-                name: fixTyped(DEFAULTS[type], unc, "name", ["string"]),
+                name: fixTyped(DEFAULTS[type], uncTyped, "name", ["string"]),
                 platforms: fixPlatforms(
                   DEFAULTS[type].platforms,
-                  unc["platforms"] ?? {},
+                  uncTyped["platforms"] ?? {},
                   Pseudoterminal.SUPPORTED_PLATFORMS,
                 ),
                 restoreHistory: fixTyped(
                   DEFAULTS[type],
-                  unc,
+                  uncTyped,
                   "restoreHistory",
                   ["boolean"],
                 ),
                 rightClickAction: fixInSet(
                   DEFAULTS[type],
-                  unc,
+                  uncTyped,
                   "rightClickAction",
                   RightClickActionAddon.ACTIONS,
                 ),
                 successExitCodes: fixArray(
                   DEFAULTS[type],
-                  unc,
+                  uncTyped,
                   "successExitCodes",
                   ["string"],
                 ),
-                terminalOptions: fixTerminalOptions(unc["terminalOptions"])
+                terminalOptions: fixTerminalOptions(uncTyped["terminalOptions"])
                   .value,
                 type,
               } satisfies Typed<typeof type>;
             }
             case "integrated": {
+              const uncTyped: Unchecked<Typed<typeof type>> = unc;
               return {
-                args: fixArray(DEFAULTS[type], unc, "args", ["string"]),
-                environment: fixEnvironment(unc["environment"]),
-                executable: fixTyped(DEFAULTS[type], unc, "executable", [
+                args: fixArray(DEFAULTS[type], uncTyped, "args", ["string"]),
+                environment: fixEnvironment(uncTyped["environment"]),
+                executable: fixTyped(DEFAULTS[type], uncTyped, "executable", [
                   "string",
                 ]),
-                followTheme: fixTyped(DEFAULTS[type], unc, "followTheme", [
+                followTheme: fixTyped(DEFAULTS[type], uncTyped, "followTheme", [
                   "boolean",
                 ]),
-                name: fixTyped(DEFAULTS[type], unc, "name", ["string"]),
+                name: fixTyped(DEFAULTS[type], uncTyped, "name", ["string"]),
                 platforms: fixPlatforms(
                   DEFAULTS[type].platforms,
-                  unc["platforms"] ?? {},
+                  uncTyped["platforms"] ?? {},
                   Pseudoterminal.SUPPORTED_PLATFORMS,
                 ),
                 pythonExecutable: fixTyped(
                   DEFAULTS[type],
-                  unc,
+                  uncTyped,
                   "pythonExecutable",
                   ["string"],
                 ),
                 restoreHistory: fixTyped(
                   DEFAULTS[type],
-                  unc,
+                  uncTyped,
                   "restoreHistory",
                   ["boolean"],
                 ),
                 rightClickAction: fixInSet(
                   DEFAULTS[type],
-                  unc,
+                  uncTyped,
                   "rightClickAction",
                   RightClickActionAddon.ACTIONS,
                 ),
                 successExitCodes: fixArray(
                   DEFAULTS[type],
-                  unc,
+                  uncTyped,
                   "successExitCodes",
                   ["string"],
                 ),
-                terminalOptions: fixTerminalOptions(unc["terminalOptions"])
+                terminalOptions: fixTerminalOptions(uncTyped["terminalOptions"])
                   .value,
                 type,
                 useWin32Conhost: fixTyped(
                   DEFAULTS[type],
-                  unc,
+                  uncTyped,
                   "useWin32Conhost",
                   ["boolean"],
                 ),
@@ -992,12 +1005,6 @@ export namespace Settings {
             "drawBoldTextInBrightColors",
             ["undefined", "boolean"],
           ),
-          fastScrollModifier: fixInSet(
-            DEFAULT_TERMINAL_OPTIONS,
-            unc,
-            "fastScrollModifier",
-            [void 0, "alt", "ctrl", "none", "shift"],
-          ),
           fastScrollSensitivity: fixTyped(
             DEFAULT_TERMINAL_OPTIONS,
             unc,
@@ -1087,7 +1094,7 @@ export namespace Settings {
                         "undefined",
                         "function",
                       ]) as ILinkHandler["leave"],
-                    } satisfies Required<DeepUndefinable<ILinkHandler>>;
+                    } satisfies CompleteUndefinable<ILinkHandler>;
                   return {
                     ...omitBy(ret, isUndefined),
                     activate: ret.activate,
@@ -1126,7 +1133,7 @@ export namespace Settings {
                       warn: fixTyped(DEFAULT_LOGGER, unc2, "warn", [
                         "function",
                       ]) as ILogger["warn"],
-                    } satisfies Required<DeepUndefinable<ILogger>>;
+                    } satisfies CompleteUndefinable<ILogger>;
                   return {
                     ...omitBy(ret, isUndefined),
                     debug: ret.debug,
@@ -1154,11 +1161,38 @@ export namespace Settings {
             "minimumContrastRatio",
             ["undefined", "number"],
           ),
-          overviewRulerWidth: fixTyped(
+          overviewRuler:
+            unc.overviewRuler === void 0
+              ? unc.overviewRuler
+              : ((): IOverviewRulerOptions => {
+                  const unc2 = launderUnchecked<IOverviewRulerOptions>(
+                      unc.overviewRuler,
+                    ),
+                    ret = {
+                      showBottomBorder: fixTyped(
+                        DEFAULT_OVERVIEW_RULER,
+                        unc2,
+                        "showBottomBorder",
+                        ["undefined", "boolean"],
+                      ),
+                      showTopBorder: fixTyped(
+                        DEFAULT_OVERVIEW_RULER,
+                        unc2,
+                        "showTopBorder",
+                        ["undefined", "boolean"],
+                      ),
+                      width: fixTyped(DEFAULT_OVERVIEW_RULER, unc2, "width", [
+                        "undefined",
+                        "number",
+                      ]),
+                    } satisfies CompleteUndefinable<IOverviewRulerOptions>;
+                  return omitBy(ret, isUndefined);
+                })(),
+          reflowCursorLine: fixTyped(
             DEFAULT_TERMINAL_OPTIONS,
             unc,
-            "overviewRulerWidth",
-            ["undefined", "number"],
+            "reflowCursorLine",
+            ["undefined", "boolean"],
           ),
           rescaleOverlappingGlyphs: fixTyped(
             DEFAULT_TERMINAL_OPTIONS,
@@ -1176,6 +1210,12 @@ export namespace Settings {
             DEFAULT_TERMINAL_OPTIONS,
             unc,
             "screenReaderMode",
+            ["undefined", "boolean"],
+          ),
+          scrollOnEraseInDisplay: fixTyped(
+            DEFAULT_TERMINAL_OPTIONS,
+            unc,
+            "scrollOnEraseInDisplay",
             ["undefined", "boolean"],
           ),
           scrollOnUserInput: fixTyped(
@@ -1297,10 +1337,34 @@ export namespace Settings {
                         "undefined",
                         "string",
                       ]),
+                      overviewRulerBorder: fixTyped(
+                        DEFAULT_THEME,
+                        unc2,
+                        "overviewRulerBorder",
+                        ["undefined", "string"],
+                      ),
                       red: fixTyped(DEFAULT_THEME, unc2, "red", [
                         "undefined",
                         "string",
                       ]),
+                      scrollbarSliderActiveBackground: fixTyped(
+                        DEFAULT_THEME,
+                        unc2,
+                        "scrollbarSliderActiveBackground",
+                        ["undefined", "string"],
+                      ),
+                      scrollbarSliderBackground: fixTyped(
+                        DEFAULT_THEME,
+                        unc2,
+                        "scrollbarSliderBackground",
+                        ["undefined", "string"],
+                      ),
+                      scrollbarSliderHoverBackground: fixTyped(
+                        DEFAULT_THEME,
+                        unc2,
+                        "scrollbarSliderHoverBackground",
+                        ["undefined", "string"],
+                      ),
                       selectionBackground: fixTyped(
                         DEFAULT_THEME,
                         unc2,
@@ -1327,7 +1391,7 @@ export namespace Settings {
                         "undefined",
                         "string",
                       ]),
-                    } satisfies Required<DeepUndefinable<ITheme>>;
+                    } satisfies CompleteUndefinable<ITheme>;
                   return omitBy(ret, isUndefined);
                 })(),
           windowOptions:
@@ -1470,13 +1534,9 @@ export namespace Settings {
                         "setWinSizePixels",
                         ["undefined", "boolean"],
                       ),
-                    } satisfies Required<DeepUndefinable<IWindowOptions>>;
+                    } satisfies CompleteUndefinable<IWindowOptions>;
                   return omitBy(ret, isUndefined);
                 })(),
-          windowsMode: fixTyped(DEFAULT_TERMINAL_OPTIONS, unc, "windowsMode", [
-            "undefined",
-            "boolean",
-          ]),
           windowsPty:
             unc.windowsPty === void 0
               ? unc.windowsPty
@@ -1494,7 +1554,7 @@ export namespace Settings {
                         "buildNumber",
                         ["undefined", "number"],
                       ),
-                    } satisfies Required<DeepUndefinable<IWindowsPty>>;
+                    } satisfies CompleteUndefinable<IWindowsPty>;
                   return omitBy(ret, isUndefined);
                 })(),
           wordSeparator: fixTyped(
@@ -1503,7 +1563,7 @@ export namespace Settings {
             "wordSeparator",
             ["undefined", "string"],
           ),
-        } satisfies Required<DeepUndefinable<TerminalOptions>>;
+        } satisfies CompleteUndefinable<TerminalOptions>;
       return markFixed(self0, {
         ...omitBy(ret2, isUndefined),
         documentOverride: DEFAULT_TERMINAL_OPTIONS.documentOverride,
@@ -1605,12 +1665,12 @@ export namespace Settings {
       // defaultProfile will be validated against fixedProfiles
       defaultProfile: ((): Settings.DefaultProfile => {
         const raw = unc.defaultProfile;
-        if (isNil(raw)) {
+        // Profile keys are strings; any other type cannot name a profile.
+        if (typeof raw !== "string") {
           return null;
         }
-        const rp = String(raw);
-        if (rp && fixedProfiles[rp] !== undefined) {
-          return rp as Settings.DefaultProfile;
+        if (raw && fixedProfiles[raw] !== undefined) {
+          return raw;
         }
         return null;
       })(),

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -11,7 +11,8 @@ import {
   resetButton,
   setTextToEnum,
 } from "@polyipseity/obsidian-plugin-library";
-import { cloneDeep, size } from "lodash-es";
+import { cloneDeep, size } from "es-toolkit/compat";
+import { sanitizeHTMLToDom } from "obsidian";
 import semverLt from "semver/functions/lt.js";
 import type { loadDocumentations } from "./documentations.js";
 import type { TerminalPlugin } from "./main.js";
@@ -212,8 +213,7 @@ export class SettingTab extends AdvancedSettingTab<Settings> {
               async (value) =>
                 settings.mutate((settingsM) => {
                   // Unfortunately we have to use the empty string as a sentinel value for "no default profile" because the dropdown component doesn't allow null/undefined values. So we have to coerce it back to null here.
-                  settingsM.defaultProfile =
-                    value === "" ? null : (value as Settings.DefaultProfile);
+                  settingsM.defaultProfile = value === "" ? null : value;
                 }),
               () => {
                 this.postMutate();
@@ -720,8 +720,10 @@ export class SettingTab extends AdvancedSettingTab<Settings> {
         .setDesc(
           createDocumentFragment(settingEl.ownerDocument, (frag) => {
             createChildElement(frag, "span", (ele) => {
-              ele.innerHTML = i18n.t(
-                "settings.expose-internal-modules-description-HTML",
+              ele.replaceChildren(
+                sanitizeHTMLToDom(
+                  i18n.t("settings.expose-internal-modules-description-HTML"),
+                ),
               );
             });
           }),

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,3 +1,12 @@
 @import "@polyipseity/obsidian-plugin-library/style";
 @import "./terminal/emulator.css";
 @import "./terminal/view.css";
+
+/* Utility classes for dynamic element state. */
+.terminal\:hidden {
+  visibility: hidden;
+}
+
+.terminal\:full-width {
+  width: 100%;
+}

--- a/src/terminal/emulator-addons.ts
+++ b/src/terminal/emulator-addons.ts
@@ -1,19 +1,19 @@
 import {
-    Functions,
-    type PluginContext,
-    activeSelf,
-    consumeEvent,
-    deepFreeze,
-    dynamicRequire,
-    isNonNil,
-    replaceAllRegex,
-    revealPrivate,
+  Functions,
+  type PluginContext,
+  activeSelf,
+  consumeEvent,
+  deepFreeze,
+  dynamicRequire,
+  isNonNil,
+  replaceAllRegex,
+  revealPrivate,
 } from "@polyipseity/obsidian-plugin-library";
 import type { CanvasAddon } from "@xterm/addon-canvas";
 import type { WebglAddon } from "@xterm/addon-webgl";
 import type { ILink, ITerminalAddon, ITheme, Terminal } from "@xterm/xterm";
 import { eastAsianWidth } from "get-east-asian-width";
-import { constant, isUndefined } from "lodash-es";
+import { constant, isUndefined } from "es-toolkit/compat";
 import { around } from "monkey-around";
 import { noop } from "ts-essentials";
 import { BUNDLE } from "../imports.js";
@@ -27,7 +27,6 @@ export class DisposerAddon extends Functions implements ITerminalAddon {
     super({ async: false, settled: true }, ...args);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public activate(_terminal: Terminal): void {
     // Noop
   }
@@ -82,6 +81,8 @@ export class DragAndDropAddon implements ITerminalAddon {
         // Fallback to legacy File.path property (Electron < 32).
         // This property is non-standard and removed in Electron 32+, but provides
         // compatibility with older versions that may not have webUtils.
+        // eslint-disable-next-line eslint-comments/no-restricted-disable -- Need to suppress no-deprecated (see below)
+        // eslint-disable-next-line @typescript-eslint/no-deprecated -- Intentional fallback for Electron versions without `webUtils.getPathForFile`.
         return file.path;
       };
 
@@ -112,7 +113,7 @@ export class DragAndDropAddon implements ITerminalAddon {
       );
       element.addEventListener("drop", drop);
       element.addEventListener("dragover", dragover);
-    })().catch((error) => {
+    })().catch((error: unknown) => {
       // Log errors from the async initialization to help with debugging.
       activeSelf(element).console.error(error);
     });
@@ -250,12 +251,10 @@ export class FollowThemeAddon implements ITerminalAddon {
     }
 
     // Robust path: let the browser resolve var(...) into a concrete color
+    // eslint-disable-next-line eslint-comments/no-restricted-disable -- Need to suppress prefer-create-el (see below)
+    // eslint-disable-next-line obsidianmd/prefer-create-el -- Probe must be created in `doc` (a possibly-popout document); the global `createDiv` binds to the main window.
     const probe = doc.createElement("div");
-    probe.style.position = "absolute";
-    probe.style.width = "0";
-    probe.style.height = "0";
-    probe.style.pointerEvents = "none";
-    probe.style.visibility = "hidden";
+    probe.classList.add("terminal:color-probe");
     probe.style.backgroundColor = `var(${varName})`;
     const resolved = ((): string => {
       attachTo.appendChild(probe);
@@ -275,14 +274,14 @@ export class FollowThemeAddon implements ITerminalAddon {
       blue = Math.round(color.blue);
 
     if (color.alpha === FollowThemeAddon.#COLOR_ALPHA_OPAQUE) {
-      return `rgb(${red}, ${green}, ${blue})`;
+      return `rgb(${String(red)}, ${String(green)}, ${String(blue)})`;
     }
 
     const alpha = Number(
       color.alpha.toFixed(FollowThemeAddon.#RGBA_ALPHA_DECIMALS),
     );
 
-    return `rgba(${red}, ${green}, ${blue}, ${alpha})`;
+    return `rgba(${String(red)}, ${String(green)}, ${String(blue)}, ${String(alpha)})`;
   }
 
   /** WCAG relative luminance of sRGB color */
@@ -556,8 +555,10 @@ export class FollowThemeAddon implements ITerminalAddon {
       return null;
     }
 
+    // eslint-disable-next-line eslint-comments/no-restricted-disable -- Need to suppress prefer-create-el (see below)
+    // eslint-disable-next-line obsidianmd/prefer-create-el -- Probe must be created in `doc` (a possibly-popout document); the global `createSpan` binds to the main window.
     const span = doc.createElement("span");
-    span.style.color = "";
+    // A fresh element has an empty `color`; assigning the input tests whether the browser can parse it.
     span.style.color = input ?? "";
 
     if (span.style.color === "") {
@@ -680,7 +681,7 @@ export class RightClickActionAddon implements ITerminalAddon {
       if (action === "default") {
         return;
       }
-      (async (): Promise<void> => {
+      void (async (): Promise<void> => {
         try {
           switch (action) {
             case "nothing":
@@ -695,7 +696,7 @@ export class RightClickActionAddon implements ITerminalAddon {
                 terminal.clearSelection();
                 break;
               }
-            // eslint-disable-next-line no-fallthrough
+            // eslint-disable-next-line no-fallthrough -- `copyPaste` without a selection intentionally falls through to paste.
             case "paste":
               terminal.paste(
                 await activeSelf(element).navigator.clipboard.readText(),
@@ -947,7 +948,7 @@ export class AltScreenExitAddon implements ITerminalAddon {
       { prefix: "?", final: "l" },
       (params) => {
         if (params[0] === 1049) {
-          setTimeout(() => {
+          window.setTimeout(() => {
             terminal.scrollToBottom();
           }, 0);
         }
@@ -1126,7 +1127,7 @@ export class VaultFileLinksAddon implements ITerminalAddon {
    * counting double-width (CJK and ambiguous-width) characters as 2 columns. */
   static visualColumn(text: string, charIndex: number): number {
     let col = 0;
-    for (let i = 0; i < charIndex && i < text.length; ) {
+    for (let i = 0; i < charIndex && i < text.length;) {
       const cp = text.codePointAt(i) ?? 0;
       col += eastAsianWidth(cp, { ambiguousAsWide: true });
       i += cp > 0xffff ? 2 : 1;
@@ -1152,7 +1153,7 @@ export class VaultFileLinksAddon implements ITerminalAddon {
         start: { x: startX, y: bufferLineNumber },
       },
       text: filePath,
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
       activate(_event: MouseEvent, _text: string): void {
         app.workspace
           .getLeaf(false)

--- a/src/terminal/emulator.css
+++ b/src/terminal/emulator.css
@@ -1,1 +1,10 @@
 @import "@xterm/xterm/css/xterm.css";
+
+/* Hidden off-screen probe used to resolve CSS variables into concrete colors. */
+.terminal\:color-probe {
+  height: 0;
+  pointer-events: none;
+  position: absolute;
+  visibility: hidden;
+  width: 0;
+}

--- a/src/terminal/emulator.ts
+++ b/src/terminal/emulator.ts
@@ -1,28 +1,28 @@
 import {
-    type Fixed,
-    SI_PREFIX_SCALE,
-    activeSelf,
-    asyncDebounce,
-    deepFreeze,
-    dynamicRequire,
-    dynamicRequireLazy,
-    fixTyped,
-    importable,
-    launderUnchecked,
-    markFixed,
+  type Fixed,
+  SI_PREFIX_SCALE,
+  activeSelf,
+  asyncDebounce,
+  deepFreeze,
+  dynamicRequire,
+  dynamicRequireLazy,
+  fixTyped,
+  importable,
+  launderUnchecked,
+  markFixed,
 } from "@polyipseity/obsidian-plugin-library";
 import type {
-    ITerminalInitOnlyOptions,
-    ITerminalOptions,
-    Terminal,
+  ITerminalInitOnlyOptions,
+  ITerminalOptions,
+  Terminal,
 } from "@xterm/xterm";
-import { noop, throttle } from "lodash-es";
+import { noop, throttle } from "es-toolkit/compat";
 import type { ChildProcessByStdio } from "node:child_process";
 import type { AsyncOrSync } from "ts-essentials";
 import { BUNDLE } from "../imports.js";
 import {
-    TERMINAL_EMULATOR_RESIZE_WAIT,
-    TERMINAL_PTY_RESIZE_WAIT,
+  TERMINAL_EMULATOR_RESIZE_WAIT,
+  TERMINAL_PTY_RESIZE_WAIT,
 } from "../magic.js";
 import { spawnPromise } from "../utils.js";
 import { applyEnv } from "./environment.js";
@@ -265,7 +265,8 @@ export namespace XtermTerminalEmulator {
     readonly rows: number;
     readonly data: string;
 
-    readonly scrollLine: (typeof State)["SCROLL_LINE_BOTTOM"] | number;
+    /** Line number, or {@link State.SCROLL_LINE_BOTTOM} to pin to the bottom. */
+    readonly scrollLine: number;
   }
   export namespace State {
     export const SCROLL_LINE_BOTTOM = -1;

--- a/src/terminal/environment.ts
+++ b/src/terminal/environment.ts
@@ -1,15 +1,15 @@
 import {
-    Platform,
-    deopaque,
-    dynamicRequire,
-    lazyInit,
+  Platform,
+  deopaque,
+  dynamicRequire,
+  lazyInit,
 } from "@polyipseity/obsidian-plugin-library";
 
 import { BUNDLE } from "../imports.js";
 import {
-    DEFAULT_PYTHONIOENCODING,
-    TERM_PROGRAM,
-    TERM_PROGRAM_VERSION,
+  DEFAULT_PYTHONIOENCODING,
+  TERM_PROGRAM,
+  TERM_PROGRAM_VERSION,
 } from "../magic.js";
 import { spawnPromise } from "../utils.js";
 
@@ -278,7 +278,7 @@ function mergeEnvPairs(
     const upperKeys = new Set(pairs.map(([k]) => k.toUpperCase()));
     for (const key of Object.keys(env)) {
       if (upperKeys.has(key.toUpperCase())) {
-        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- Remove the case-colliding key from the plain env record.
         delete env[key];
       }
     }

--- a/src/terminal/load.ts
+++ b/src/terminal/load.ts
@@ -7,7 +7,7 @@ import {
   isNonNil,
   notice2,
 } from "@polyipseity/obsidian-plugin-library";
-import { isEmpty } from "lodash-es";
+import { isEmpty } from "es-toolkit/compat";
 import {
   FileSystemAdapter,
   MarkdownView,
@@ -25,9 +25,7 @@ export function loadTerminal(context: TerminalPlugin): void {
   const PROFILE_TYPES = deepFreeze(
       (
         ["default", "external", "integrated", "select"] satisfies readonly (
-          | "default"
-          | "select"
-          | keyof typeof PROFILE_PROPERTIES
+          "default" | "select" | keyof typeof PROFILE_PROPERTIES
         )[]
       ).filter(
         (type) =>
@@ -103,9 +101,6 @@ export function loadTerminal(context: TerminalPlugin): void {
       (type: (typeof PROFILE_TYPES)[number], cwd: (typeof CWD_TYPES)[number]) =>
       (checking: boolean): boolean => {
         const cwd0 = ((): string | null | undefined => {
-          if (!cwd) {
-            return void 0;
-          }
           if (!adapter) {
             return null;
           }

--- a/src/terminal/options.ts
+++ b/src/terminal/options.ts
@@ -1,5 +1,5 @@
 import type { Settings } from "../settings-data.js";
-import { cloneDeep, isEqual } from "lodash-es";
+import { cloneDeep, isEqual } from "es-toolkit/compat";
 import { cloneAsWritable } from "@polyipseity/obsidian-plugin-library";
 import type { DeepWritable } from "ts-essentials";
 import type { Terminal, ITerminalOptions } from "@xterm/xterm";
@@ -47,12 +47,14 @@ export function applyTerminalOptionDiffShallow(
     ...Object.keys(curOpts),
   ]);
   for (const key of allKeys) {
-    const prevVal = prevOpts[key as keyof typeof prevOpts];
-    const curVal = curOpts[key as keyof typeof curOpts];
+    // `unknown` avoids the `any` that leaks from `documentOverride: any`.
+    const prevVal: unknown = prevOpts[key as keyof typeof prevOpts];
+    const curVal: unknown = curOpts[key as keyof typeof curOpts];
     if (!isEqual(prevVal, curVal)) {
       // assign a deep clone to avoid accidental shared references
-      terminal.options[key as keyof typeof terminal.options] =
-        cloneDeep(curVal);
+      terminal.options[key as keyof typeof terminal.options] = cloneDeep(
+        curVal,
+      ) as never;
     }
   }
 }

--- a/src/terminal/profile-presets.ts
+++ b/src/terminal/profile-presets.ts
@@ -6,6 +6,7 @@ import {
 import type {
   ILinkHandler,
   ILogger,
+  IOverviewRulerOptions,
   ITheme,
   IWindowOptions,
   IWindowsPty,
@@ -20,8 +21,7 @@ import type { Pseudoterminal } from "./pseudoterminal.js";
 import type { Settings } from "../settings-data.js";
 
 export const DEFAULT_LINK_HANDLER: ILinkHandler = deepFreeze({
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    activate(event, text, range) {
+    activate(event, text, _range) {
       openExternal(activeSelf(event), text);
     },
   }),
@@ -42,6 +42,7 @@ export const DEFAULT_LINK_HANDLER: ILinkHandler = deepFreeze({
       self.console.warn(message, ...args);
     },
   }),
+  DEFAULT_OVERVIEW_RULER: IOverviewRulerOptions = deepFreeze({}),
   DEFAULT_TERMINAL_OPTIONS: Settings.Profile.TerminalOptions = deepFreeze({
     documentOverride: null,
   }),
@@ -90,6 +91,7 @@ export interface ProfilePresets
 const PROFILE_PRESETS0 = deepFreeze({
   bashIntegrated: {
     args: ["--login"],
+    environment: [],
     executable: "/bin/bash",
     followTheme: true,
     name: "",
@@ -104,6 +106,7 @@ const PROFILE_PRESETS0 = deepFreeze({
   },
   cmdExternal: {
     args: [],
+    environment: [],
     executable: WINDOWS_CMD_PATH,
     followTheme: true,
     name: "",
@@ -116,6 +119,7 @@ const PROFILE_PRESETS0 = deepFreeze({
   },
   cmdIntegrated: {
     args: [],
+    environment: [],
     executable: WINDOWS_CMD_PATH,
     followTheme: true,
     name: "",
@@ -130,6 +134,7 @@ const PROFILE_PRESETS0 = deepFreeze({
   },
   dashIntegrated: {
     args: [],
+    environment: [],
     executable: "/bin/dash",
     followTheme: true,
     name: "",
@@ -162,6 +167,7 @@ const PROFILE_PRESETS0 = deepFreeze({
   },
   gitBashIntegrated: {
     args: ["--login"],
+    environment: [],
     executable: "C:\\Program Files\\Git\\bin\\bash.exe",
     followTheme: true,
     name: "",
@@ -176,6 +182,7 @@ const PROFILE_PRESETS0 = deepFreeze({
   },
   gnomeTerminalExternal: {
     args: [],
+    environment: [],
     executable: "gnome-terminal",
     followTheme: true,
     name: "",
@@ -188,6 +195,7 @@ const PROFILE_PRESETS0 = deepFreeze({
   },
   iTerm2External: {
     args: ['"$PWD"'],
+    environment: [],
     executable: "/Applications/iTerm.app/Contents/MacOS/iTerm2",
     followTheme: true,
     name: "",
@@ -200,6 +208,7 @@ const PROFILE_PRESETS0 = deepFreeze({
   },
   konsoleExternal: {
     args: [],
+    environment: [],
     executable: "konsole",
     followTheme: true,
     name: "",
@@ -212,6 +221,7 @@ const PROFILE_PRESETS0 = deepFreeze({
   },
   powershellExternal: {
     args: [],
+    environment: [],
     executable: "powershell",
     followTheme: true,
     name: "",
@@ -224,6 +234,7 @@ const PROFILE_PRESETS0 = deepFreeze({
   },
   powershellIntegrated: {
     args: [],
+    environment: [],
     executable: "powershell",
     followTheme: true,
     name: "",
@@ -238,6 +249,7 @@ const PROFILE_PRESETS0 = deepFreeze({
   },
   pwshExternal: {
     args: [],
+    environment: [],
     executable: "pwsh",
     followTheme: true,
     name: "",
@@ -250,6 +262,7 @@ const PROFILE_PRESETS0 = deepFreeze({
   },
   pwshIntegrated: {
     args: [],
+    environment: [],
     executable: "pwsh",
     followTheme: true,
     name: "",
@@ -264,6 +277,7 @@ const PROFILE_PRESETS0 = deepFreeze({
   },
   shIntegrated: {
     args: [],
+    environment: [],
     executable: "/bin/sh",
     followTheme: true,
     name: "",
@@ -278,6 +292,7 @@ const PROFILE_PRESETS0 = deepFreeze({
   },
   terminalMacOSExternal: {
     args: ['"$PWD"'],
+    environment: [],
     executable:
       "/System/Applications/Utilities/Terminal.app/Contents/macOS/Terminal",
     followTheme: true,
@@ -291,6 +306,7 @@ const PROFILE_PRESETS0 = deepFreeze({
   },
   wslIntegrated: {
     args: [],
+    environment: [],
     executable: "C:\\Windows\\System32\\wsl.exe",
     followTheme: true,
     name: "",
@@ -305,6 +321,7 @@ const PROFILE_PRESETS0 = deepFreeze({
   },
   wtExternal: {
     args: [],
+    environment: [],
     executable: "wt",
     followTheme: true,
     name: "",
@@ -317,6 +334,7 @@ const PROFILE_PRESETS0 = deepFreeze({
   },
   xtermExternal: {
     args: [],
+    environment: [],
     executable: "xterm",
     followTheme: true,
     name: "",
@@ -329,6 +347,7 @@ const PROFILE_PRESETS0 = deepFreeze({
   },
   zshIntegrated: {
     args: ["--login"],
+    environment: [],
     executable: "/bin/zsh",
     followTheme: true,
     name: "",

--- a/src/terminal/pseudoterminal.ts
+++ b/src/terminal/pseudoterminal.ts
@@ -1,52 +1,52 @@
 import {
-    Functions,
-    Platform,
-    ResourceComponent,
-    SI_PREFIX_SCALE,
-    acquireConditionally,
-    activeSelf,
-    anyToError,
-    asyncFunction,
-    attachFunctionSourceMap,
-    clear,
-    consumeEvent,
-    deepFreeze,
-    deopaque,
-    dynamicRequire,
-    getKeyModifiers,
-    inSet,
-    lazyInit,
-    logFormat,
-    multireplace,
-    notice2,
-    printError,
-    promisePromise,
-    remove,
-    replaceAllRegex,
-    sleep2,
-    toJSONOrString,
-    typedKeys,
+  Functions,
+  Platform,
+  ResourceComponent,
+  SI_PREFIX_SCALE,
+  acquireConditionally,
+  activeSelf,
+  anyToError,
+  asyncFunction,
+  attachFunctionSourceMap,
+  clear,
+  consumeEvent,
+  deepFreeze,
+  deopaque,
+  dynamicRequire,
+  getKeyModifiers,
+  inSet,
+  lazyInit,
+  logFormat,
+  multireplace,
+  notice2,
+  printError,
+  promisePromise,
+  remove,
+  replaceAllRegex,
+  sleep2,
+  toJSONOrString,
+  typedKeys,
 } from "@polyipseity/obsidian-plugin-library";
 import type { IMarker, Terminal } from "@xterm/xterm";
 import { type Program, parse } from "acorn";
 import inspect, { type Options } from "browser-util-inspect";
-import { isEmpty, isNil, noop } from "lodash-es";
+import { isEmpty, isNil, noop } from "es-toolkit/compat";
 import {
-    DEFAULT_ENCODING,
-    EXIT_SUCCESS,
-    MAX_LOCK_PENDING,
-    TERMINAL_EXIT_CLEANUP_WAIT,
-    TERMINAL_RESIZER_WATCHDOG_WAIT,
-    WINDOWS_CONHOST_PATH,
+  DEFAULT_ENCODING,
+  EXIT_SUCCESS,
+  MAX_LOCK_PENDING,
+  TERMINAL_EXIT_CLEANUP_WAIT,
+  TERMINAL_RESIZER_WATCHDOG_WAIT,
+  WINDOWS_CONHOST_PATH,
 } from "../magic.js";
 import { spawnPromise, writePromise } from "../utils.js";
 import {
-    CONTROL_SEQUENCE_INTRODUCER as CSI,
-    CursoredText,
-    NORMALIZED_LINE_FEED,
-    TerminalTextArea,
-    normalizeText,
-    writePromise as tWritePromise,
+  CONTROL_SEQUENCE_INTRODUCER as CSI,
+  CursoredText,
+  NORMALIZED_LINE_FEED,
+  TerminalTextArea,
+  normalizeText,
+  writePromise as tWritePromise,
 } from "./utils.js";
 
 import ansi from "ansi-escape-sequences";
@@ -261,7 +261,7 @@ export class DeveloperConsolePseudoterminal
   >();
 
   public constructor(
-    protected readonly self0: () => Window & typeof globalThis,
+    protected readonly self0: () => Window & typeof window,
     protected readonly log: Log,
     protected readonly sourceRoot = "",
   ) {
@@ -330,6 +330,7 @@ export class DeveloperConsolePseudoterminal
                   await this.syncBuffer(terminals, false);
                 });
 
+              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- The write callbacks clear `writing` while `syncBuffer` is awaited.
               while (writing) {
                 await this.syncBuffer(terminals, false);
               }
@@ -379,6 +380,7 @@ export class DeveloperConsolePseudoterminal
                     })
                     .then(async () => this.syncBuffer(terminals, false));
 
+                  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- The write callbacks clear `writing` while `syncBuffer` is awaited.
                   while (writing) {
                     await this.syncBuffer(terminals, false);
                   }
@@ -463,7 +465,7 @@ export class DeveloperConsolePseudoterminal
           const {
             [style]: [apply, undo],
           } = inspect.colors;
-          return `${CSI}${apply}m${str}${CSI}${undo}m${ansi.styles(styles)}`;
+          return `${CSI}${String(apply)}m${str}${CSI}${String(undo)}m${ansi.styles(styles)}`;
         }
         return str;
       },
@@ -520,7 +522,7 @@ export class DeveloperConsolePseudoterminal
     if (lastStmtLoc) {
       const { start, end } = lastStmtLoc;
       let column = 0;
-      // eslint-disable-next-line no-empty-pattern
+      // eslint-disable-next-line no-empty-pattern -- Iterate once per character; only the count matters.
       for (const {} of "return [(") {
         codeRetDeletions.push({
           column: start.column + column,
@@ -531,7 +533,7 @@ export class DeveloperConsolePseudoterminal
       if (start.line !== end.line) {
         column = 0;
       }
-      // eslint-disable-next-line no-empty-pattern
+      // eslint-disable-next-line no-empty-pattern -- Iterate once per character; only the count matters.
       for (const {} of ")]") {
         codeRetDeletions.push({
           column: end.column + column,
@@ -877,7 +879,10 @@ class WindowsPseudoterminal implements Pseudoterminal {
                 .then(async (resizer0) => {
                   if (resizer0) {
                     try {
-                      await writePromise(resizer0.stdin, `${ret.pid ?? -1}\n`);
+                      await writePromise(
+                        resizer0.stdin,
+                        `${String(ret.pid ?? -1)}\n`,
+                      );
                       const watchdog = self.setInterval(() => {
                         writePromise(resizer0.stdin, "\n").catch(
                           (error: unknown) => {
@@ -940,7 +945,7 @@ class WindowsPseudoterminal implements Pseudoterminal {
                   /* @__PURE__ */ self.console.debug(error);
                   return conCode ?? signal ?? NaN;
                 } finally {
-                  (async (): Promise<void> => {
+                  void (async (): Promise<void> => {
                     try {
                       await sleep2(self, TERMINAL_EXIT_CLEANUP_WAIT);
                       await inOutTmp.cleanup();
@@ -991,7 +996,7 @@ class WindowsPseudoterminal implements Pseudoterminal {
     if (!resizer0) {
       throw new Error(plugin.language.value.t("errors.resizer-disabled"));
     }
-    await writePromise(resizer0.stdin, `${columns}x${rows}\n`);
+    await writePromise(resizer0.stdin, `${String(columns)}x${String(rows)}\n`);
   }
 
   public async pipe(terminal: Terminal): Promise<void> {
@@ -1130,7 +1135,7 @@ class UnixPseudoterminal implements Pseudoterminal {
     if (!(cmdio instanceof stream2.Writable)) {
       throw new TypeError(toJSONOrString(cmdio));
     }
-    await writePromise(cmdio, `${columns}x${rows}\n`);
+    await writePromise(cmdio, `${String(columns)}x${String(rows)}\n`);
   }
 }
 

--- a/src/terminal/spawn.ts
+++ b/src/terminal/spawn.ts
@@ -7,7 +7,7 @@ import {
 import { FuzzySuggestModal } from "obsidian";
 import { Settings } from "../settings-data.js";
 import type { TerminalPlugin } from "../main.js";
-import { noop } from "lodash-es";
+import { noop } from "es-toolkit/compat";
 
 export class SelectProfileModal extends FuzzySuggestModal<Settings.Profile.Entry | null> {
   public constructor(
@@ -124,7 +124,7 @@ export function spawnTerminal(
     ).open();
     return;
   }
-  (async (): Promise<void> => {
+  void (async (): Promise<void> => {
     try {
       await TerminalView.spawn(context, state);
     } catch (error) {

--- a/src/terminal/utils.ts
+++ b/src/terminal/utils.ts
@@ -1,30 +1,30 @@
 import {
-    acquireConditionally,
-    alternativeRegExp,
-    cartesianProduct,
-    clear,
-    codePoint,
-    deepFreeze,
-    dynamicRequireLazy,
-    insertAt,
-    lazyProxy,
-    rangeCodePoint,
-    removeAt,
-    replaceAllRegex,
+  acquireConditionally,
+  alternativeRegExp,
+  cartesianProduct,
+  clear,
+  codePoint,
+  deepFreeze,
+  dynamicRequireLazy,
+  insertAt,
+  lazyProxy,
+  rangeCodePoint,
+  removeAt,
+  replaceAllRegex,
 } from "@polyipseity/obsidian-plugin-library";
 import type {
-    IDisposable,
-    IFunctionIdentifier,
-    Terminal,
-    ITerminalOptions as TerminalOptions,
-    ITerminalInitOnlyOptions as TerminalOptionsInit,
+  IDisposable,
+  IFunctionIdentifier,
+  Terminal,
+  ITerminalOptions as TerminalOptions,
+  ITerminalInitOnlyOptions as TerminalOptionsInit,
 } from "@xterm/xterm";
 import type { DeepReadonly, DeepRequired } from "ts-essentials";
 
 import ansi from "ansi-escape-sequences";
 import AsyncLock from "async-lock";
 import { Set as valueSet } from "immutable";
-import { range } from "lodash-es";
+import { range } from "es-toolkit/compat";
 import { BUNDLE } from "../imports.js";
 import { MAX_LOCK_PENDING } from "../magic.js";
 
@@ -275,6 +275,7 @@ export class TerminalTextArea implements IDisposable {
                   await writePromise(terminal, char);
                   consumed += char.length;
 
+                  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Another method can clear `#sequence` while `writePromise` is awaited.
                   if (!this.#sequence) {
                     break;
                   }
@@ -313,7 +314,7 @@ export class TerminalTextArea implements IDisposable {
                 if (width > 0) {
                   await writePromise(
                     terminal,
-                    `${ansi.cursor.back(width)}${CSI}${width}P`,
+                    `${ansi.cursor.back(width)}${CSI}${String(width)}P`,
                   );
                   this.#widths[cursorY] -= width;
                 } else if (cursorY > 0) {
@@ -340,11 +341,11 @@ export class TerminalTextArea implements IDisposable {
               const reserve = MAX_CHARACTER_WIDTH * datum.length;
               terminal.resize(terminal.cols + reserve, terminal.rows);
 
-              await writePromise(terminal, `${CSI}${reserve}@${datum}`);
+              await writePromise(terminal, `${CSI}${String(reserve)}@${datum}`);
               this.#widths[cursorY] += reserve;
               const lossX = reserve - (active.cursorX - cursorX);
 
-              await writePromise(terminal, `${CSI}${lossX}P`);
+              await writePromise(terminal, `${CSI}${String(lossX)}P`);
               this.#widths[cursorY] -= lossX;
               break;
             }

--- a/src/terminal/view.ts
+++ b/src/terminal/view.ts
@@ -1,84 +1,84 @@
 import {
-    DialogModal,
-    FindComponent,
-    type FindComponent$,
-    type Fixed,
-    JSON_STRINGIFY_SPACE,
-    Platform,
-    UnnamespacedID,
-    activeSelf,
-    addCommand,
-    anyToError,
-    assignExact,
-    awaitCSS,
-    basename,
-    cloneAsWritable,
-    createChildElement,
-    deepFreeze,
-    dynamicRequire,
-    extname,
-    fixTyped,
-    instanceOf,
-    launderUnchecked,
-    linkSetting,
-    markFixed,
-    newCollaborativeState,
-    newHotkeyListener,
-    notice2,
-    onResize,
-    openExternal,
-    printError,
-    printMalformedData,
-    randomNotIn,
-    readStateCollaboratively,
-    recordViewStateHistory,
-    resetButton,
-    saveFileAs,
-    svelteState,
-    updateView,
-    useSettings,
-    writeStateCollaboratively,
+  DialogModal,
+  FindComponent,
+  type FindComponent$,
+  type Fixed,
+  JSON_STRINGIFY_SPACE,
+  Platform,
+  UnnamespacedID,
+  activeSelf,
+  addCommand,
+  anyToError,
+  assignExact,
+  awaitCSS,
+  basename,
+  cloneAsWritable,
+  createChildElement,
+  deepFreeze,
+  dynamicRequire,
+  extname,
+  fixTyped,
+  instanceOf,
+  launderUnchecked,
+  linkSetting,
+  markFixed,
+  newCollaborativeState,
+  newHotkeyListener,
+  notice2,
+  onResize,
+  openExternal,
+  printError,
+  printMalformedData,
+  randomNotIn,
+  readStateCollaboratively,
+  recordViewStateHistory,
+  resetButton,
+  saveFileAs,
+  svelteState,
+  updateView,
+  useSettings,
+  writeStateCollaboratively,
 } from "@polyipseity/obsidian-plugin-library";
 import type { LigaturesAddon } from "@xterm/addon-ligatures";
 import type { SearchAddon } from "@xterm/addon-search";
 import type { Unicode11Addon } from "@xterm/addon-unicode11";
 import type { WebLinksAddon } from "@xterm/addon-web-links";
 import { type ITerminalOptions, Terminal } from "@xterm/xterm";
-import { noop } from "lodash-es";
+import { noop } from "es-toolkit/compat";
 import {
-    FileSystemAdapter,
-    ItemView,
-    type Menu,
-    Scope,
-    type ViewStateResult,
-    type WorkspaceLeaf,
+  FileSystemAdapter,
+  ItemView,
+  type Menu,
+  Scope,
+  type ViewStateResult,
+  type WorkspaceLeaf,
 } from "obsidian";
 import { mount, unmount } from "svelte";
 import type { DeepWritable } from "ts-essentials";
 import { BUNDLE } from "../imports.js";
 import {
-    DEFAULT_ENCODING,
-    DEFAULT_SUCCESS_EXIT_CODES,
-    DOMClasses2,
+  DEFAULT_ENCODING,
+  DEFAULT_SUCCESS_EXIT_CODES,
+  DOMClasses2,
 } from "../magic.js";
 import type { TerminalPlugin } from "../main.js";
 import { ProfileModal } from "../modals.js";
 import { Settings } from "../settings-data.js";
 import {
-    AltScreenExitAddon,
-    CustomKeyEventHandlerAddon,
-    DisposerAddon,
-    DragAndDropAddon,
-    FollowThemeAddon,
-    RendererAddon,
-    RightClickActionAddon,
-    SynchronizedOutputScrollAddon,
-    VaultFileLinksAddon,
+  AltScreenExitAddon,
+  CustomKeyEventHandlerAddon,
+  DisposerAddon,
+  DragAndDropAddon,
+  FollowThemeAddon,
+  RendererAddon,
+  RightClickActionAddon,
+  SynchronizedOutputScrollAddon,
+  VaultFileLinksAddon,
 } from "./emulator-addons.js";
 import { XtermTerminalEmulator } from "./emulator.js";
 import {
-    applyTerminalOptionDiffShallow,
-    mergeTerminalOptions,
+  applyTerminalOptionDiffShallow,
+  mergeTerminalOptions,
 } from "./options.js";
 import { PROFILE_PROPERTIES, openProfile } from "./profile-properties.js";
 import { TextPseudoterminal } from "./pseudoterminal.js";
@@ -318,8 +318,8 @@ export class TerminalView extends ItemView {
   #rawTitle0 = "";
   #emulator0: TerminalView.EMULATOR | null = null;
   #find0:
-    | readonly [ReturnType<typeof FindComponent>, FindComponent$.Props]
-    | null = null;
+    readonly [ReturnType<typeof FindComponent>, FindComponent$.Props] | null =
+    null;
   #state = TerminalView.State.DEFAULT;
 
   public constructor(
@@ -344,8 +344,7 @@ export class TerminalView extends ItemView {
   }
 
   protected get find():
-    | readonly [ReturnType<typeof FindComponent>, FindComponent$.Props]
-    | null {
+    readonly [ReturnType<typeof FindComponent>, FindComponent$.Props] | null {
     return this.#find0;
   }
 
@@ -432,8 +431,7 @@ export class TerminalView extends ItemView {
 
   protected set find(
     val:
-      | readonly [ReturnType<typeof FindComponent>, FindComponent$.Props]
-      | null,
+      readonly [ReturnType<typeof FindComponent>, FindComponent$.Props] | null,
   ) {
     if (this.find) {
       unmount(this.find[0], { outro: true }).catch((error: unknown) => {
@@ -635,12 +633,13 @@ export class TerminalView extends ItemView {
     recordViewStateHistory(plugin, result);
   }
 
-  public override getState(): unknown {
+  public override getState(): Record<string, unknown> {
+    // `writeStateCollaboratively` returns the laundered state object.
     return writeStateCollaboratively(
       super.getState(),
       TerminalView.type.namespaced(this.context),
       this.state,
-    );
+    ) as Record<string, unknown>;
   }
 
   public getDisplayText(): string {
@@ -768,7 +767,7 @@ export class TerminalView extends ItemView {
 
   protected focus(): void {
     const { app, emulator, leaf } = this;
-    app.workspace.revealLeaf(leaf);
+    void app.workspace.revealLeaf(leaf);
     emulator?.terminal.focus();
   }
 
@@ -828,11 +827,11 @@ export class TerminalView extends ItemView {
                 userTitle = value;
               });
           });
-          controlEl.style.width = "100%";
+          controlEl.classList.add("terminal:full-width");
           controlEl
             .querySelectorAll<HTMLInputElement>(":scope > input")
             .forEach((input) => {
-              input.style.width = "100%";
+              input.classList.add("terminal:full-width");
             });
         });
       },
@@ -1007,7 +1006,7 @@ export class TerminalView extends ItemView {
         );
       };
     if (!PROFILE_PROPERTIES[profile.type].integratable) {
-      (async (): Promise<void> => {
+      void (async (): Promise<void> => {
         try {
           noticeSpawn();
           await openProfile(context, profile, { cwd: cwd ?? void 0 });
@@ -1027,7 +1026,7 @@ export class TerminalView extends ItemView {
         activeSelf(ele).console.warn(error);
       }
       ele.classList.add(TerminalView.type.namespaced(context));
-      (async (): Promise<void> => {
+      void (async (): Promise<void> => {
         try {
           await awaitCSS(ele);
           noticeSpawn();
@@ -1400,46 +1399,47 @@ export namespace TerminalView {
         },
         settings,
       } = context,
-      newLeaf = ((): WorkspaceLeaf => {
-        if (settings.value.createInstanceNearExistingOnes) {
-          const existingLeaves = workspace.getLeavesOfType(
-              TerminalView.type.namespaced(context),
-            ),
-            existingLeaf = leaf ?? existingLeaves[existingLeaves.length - 1];
-          if (existingLeaf) {
-            const root = existingLeaf.getRoot();
-            if (root === leftSplit) {
-              return workspace.getLeftLeaf(false);
+      newLeaf =
+        ((): WorkspaceLeaf | null => {
+          if (settings.value.createInstanceNearExistingOnes) {
+            const existingLeaves = workspace.getLeavesOfType(
+                TerminalView.type.namespaced(context),
+              ),
+              existingLeaf = leaf ?? existingLeaves[existingLeaves.length - 1];
+            if (existingLeaf) {
+              const root = existingLeaf.getRoot();
+              if (root === leftSplit) {
+                return workspace.getLeftLeaf(false);
+              }
+              if (root === rightSplit) {
+                return workspace.getRightLeaf(false);
+              }
+              workspace.setActiveLeaf(existingLeaf);
+              return workspace.getLeaf("tab");
             }
-            if (root === rightSplit) {
-              return workspace.getRightLeaf(false);
-            }
-            workspace.setActiveLeaf(existingLeaf);
-            return workspace.getLeaf("tab");
           }
-        }
-        switch (settings.value.newInstanceBehavior) {
-          case "replaceTab":
-            return workspace.getLeaf();
-          case "newTab":
-            return workspace.getLeaf("tab");
-          case "newLeftTab":
-            return workspace.getLeftLeaf(false);
-          case "newLeftSplit":
-            return workspace.getLeftLeaf(true);
-          case "newRightTab":
-            return workspace.getRightLeaf(false);
-          case "newRightSplit":
-            return workspace.getRightLeaf(true);
-          case "newHorizontalSplit":
-            return workspace.getLeaf("split", "horizontal");
-          case "newVerticalSplit":
-            return workspace.getLeaf("split", "vertical");
-          case "newWindow":
-            return workspace.getLeaf("window");
-          // No default
-        }
-      })();
+          switch (settings.value.newInstanceBehavior) {
+            case "replaceTab":
+              return workspace.getLeaf();
+            case "newTab":
+              return workspace.getLeaf("tab");
+            case "newLeftTab":
+              return workspace.getLeftLeaf(false);
+            case "newLeftSplit":
+              return workspace.getLeftLeaf(true);
+            case "newRightTab":
+              return workspace.getRightLeaf(false);
+            case "newRightSplit":
+              return workspace.getRightLeaf(true);
+            case "newHorizontalSplit":
+              return workspace.getLeaf("split", "horizontal");
+            case "newVerticalSplit":
+              return workspace.getLeaf("split", "vertical");
+            case "newWindow":
+              return workspace.getLeaf("window");
+            // No default
+          }
+        })() ?? workspace.getLeaf("tab");
     newLeaf.setPinned(settings.value.pinNewInstance);
     return newLeaf;
   }
@@ -1451,10 +1451,11 @@ export namespace TerminalView {
   ): Promise<void> {
     await (leaf ?? getLeaf(context)).setViewState({
       active: true,
+      // `newCollaborativeState` returns a frozen plain object.
       state: newCollaborativeState(
         context,
         new Map([[TerminalView.type, state]]),
-      ),
+      ) as Record<string, unknown>,
       type,
     });
   }

--- a/tests/src/settings-data.spec.ts
+++ b/tests/src/settings-data.spec.ts
@@ -36,8 +36,8 @@ describe("src/settings-data.ts", () => {
       openChangelogOnUpdate: Settings.DEFAULT.openChangelogOnUpdate,
       extra: "present",
     };
-    // Use toRecord to assert type for test ergonomics
-    const p = Settings.persistent(sample);
+    // Deliberately partial: `persistent` only touches `optionals` keys.
+    const p = Settings.persistent(sample as unknown as Settings);
     expect(p).toHaveProperty("noticeTimeout");
     // ensure extra is still present because `optionals` is empty
     expect(p).toHaveProperty("extra");
@@ -141,8 +141,7 @@ describe("src/settings-data.ts", () => {
     // even when the input is wrong type, it should coerce to null
     const alsoBad = Settings.fix({
       profiles: baseProfiles,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      defaultProfile: 123 as any,
+      defaultProfile: 123,
     });
     expect(alsoBad.value.defaultProfile).toBe(null);
   });
@@ -157,8 +156,7 @@ describe("src/settings-data.ts", () => {
 
   it("Settings.fix coerces bad showTerminalTabPrefix to default", () => {
     const bad = Settings.fix({
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      showTerminalTabPrefix: "not-a-boolean" as any,
+      showTerminalTabPrefix: "not-a-boolean",
     });
     expect(bad.value.showTerminalTabPrefix).toBe(false);
   });
@@ -169,11 +167,11 @@ describe("src/settings-data.ts", () => {
         abc123: {
           ...Settings.Profile.DEFAULTS.integrated,
           type: "integrated",
-        } as Settings.Profile,
+        },
         def456: {
           ...Settings.Profile.DEFAULTS.developerConsole,
           type: "developerConsole",
-        } as Settings.Profile,
+        },
       };
       const result = Settings.Profile.defaultEntryOfType(
         "integrated",

--- a/tests/src/terminal/emulator-addons.spec.ts
+++ b/tests/src/terminal/emulator-addons.spec.ts
@@ -207,7 +207,7 @@ describe("CustomKeyEventHandlerAddon", () => {
         shift: false,
         platform: null,
         action: "ignore",
-        actionArg: "",
+        actionArg: null,
       },
     ]);
     const result = handler(fakeKeyEvent({ key: "a", ctrlKey: true }));
@@ -225,7 +225,7 @@ describe("CustomKeyEventHandlerAddon", () => {
         shift: false,
         platform: null,
         action: "passthrough",
-        actionArg: "",
+        actionArg: null,
       },
     ]);
     const keydownResult = handler(fakeKeyEvent({ key: "a", ctrlKey: true }));
@@ -526,8 +526,6 @@ describe("SynchronizedOutputScrollAddon", () => {
   });
 
   it("returns false from both handlers so xterm processes sequences normally", () => {
-    const { terminal } = createSyncMockTerminal(0, 0);
-
     // Capture return values by overriding triggerCsi to return them
     const returnVals: boolean[] = [];
     const origHandlers: Record<
@@ -535,7 +533,9 @@ describe("SynchronizedOutputScrollAddon", () => {
       Array<(params: { [index: number]: number }) => boolean>
     > = {};
     const patchedTerminal = {
-      ...terminal,
+      buffer: { active: { baseY: 0, viewportY: 0 } },
+      scrollToBottom: vi.fn(),
+      scrollToLine: vi.fn(),
       parser: {
         registerCsiHandler(
           id: { prefix?: string; final: string },
@@ -573,7 +573,15 @@ describe("VaultFileLinksAddon", () => {
   });
 
   /** Mock file returned by getFileByPath. */
-  const MOCK_FILE = { path: "test.md", name: "test.md" } as TFile;
+  const MOCK_FILE: TFile = {
+    basename: "test",
+    extension: "md",
+    name: "test.md",
+    parent: null,
+    path: "test.md",
+    stat: { ctime: 0, mtime: 0, size: 0 },
+    vault: {} as Vault,
+  };
 
   /**
    * Creates a VaultFileLinksAddon test bed.
@@ -581,7 +589,7 @@ describe("VaultFileLinksAddon", () => {
    * @param fileExists - Whether getFileByPath should return a TFile or null.
    */
   function createBed(fileExists = true): {
-    provideLinks(lineText: string): ILink[] | undefined;
+    provideLinks: (lineText: string) => ILink[] | undefined;
     getFileByPath: ReturnType<typeof vi.fn>;
     openFile: ReturnType<typeof vi.fn>;
     getLeaf: ReturnType<typeof vi.fn>;
@@ -775,19 +783,20 @@ describe("VaultFileLinksAddon", () => {
     const context = { app } as unknown as PluginContext;
     const addon = new VaultFileLinksAddon(context);
 
-    let capturedProvider: ILinkProvider;
+    let capturedProvider: ILinkProvider | undefined;
+    const getLine = vi.fn();
     const terminal = {
       registerLinkProvider: vi.fn((p: ILinkProvider) => {
         capturedProvider = p;
         return { dispose: vi.fn() };
       }),
-      buffer: { active: { getLine: vi.fn() } },
+      buffer: { active: { getLine } },
       element: document.createElement("div"),
     } as unknown as Terminal;
     addon.activate(terminal);
 
     const line = { translateToString: vi.fn(() => "(test.md)") };
-    terminal.buffer.active.getLine.mockReturnValue(line);
+    getLine.mockReturnValue(line);
     let result: ILink[] | undefined;
     capturedProvider?.provideLinks(1, (links) => {
       result = links;

--- a/tests/src/terminal/environment.spec.ts
+++ b/tests/src/terminal/environment.spec.ts
@@ -261,12 +261,18 @@ function shouldSanitize(key: string): boolean {
 }
 
 describe("env key sanitization", () => {
-  it("strips TMUX", () => expect(shouldSanitize("TMUX")).toBe(true));
-  it("strips STY", () => expect(shouldSanitize("STY")).toBe(true));
-  it("strips TERM_PROGRAM", () =>
-    expect(shouldSanitize("TERM_PROGRAM")).toBe(true));
-  it("strips TERM_PROGRAM_VERSION", () =>
-    expect(shouldSanitize("TERM_PROGRAM_VERSION")).toBe(true));
+  it("strips TMUX", () => {
+    expect(shouldSanitize("TMUX")).toBe(true);
+  });
+  it("strips STY", () => {
+    expect(shouldSanitize("STY")).toBe(true);
+  });
+  it("strips TERM_PROGRAM", () => {
+    expect(shouldSanitize("TERM_PROGRAM")).toBe(true);
+  });
+  it("strips TERM_PROGRAM_VERSION", () => {
+    expect(shouldSanitize("TERM_PROGRAM_VERSION")).toBe(true);
+  });
   it("strips VSCODE_ prefixed keys", () => {
     expect(shouldSanitize("VSCODE_GIT_ASKPASS_NODE")).toBe(true);
     expect(shouldSanitize("VSCODE_IPC_HOOK")).toBe(true);
@@ -274,10 +280,18 @@ describe("env key sanitization", () => {
   it("strips ZED_ prefixed keys", () => {
     expect(shouldSanitize("ZED_TERM")).toBe(true);
   });
-  it("keeps PATH", () => expect(shouldSanitize("PATH")).toBe(false));
-  it("keeps HOME", () => expect(shouldSanitize("HOME")).toBe(false));
-  it("keeps TERM", () => expect(shouldSanitize("TERM")).toBe(false));
-  it("keeps SHELL", () => expect(shouldSanitize("SHELL")).toBe(false));
+  it("keeps PATH", () => {
+    expect(shouldSanitize("PATH")).toBe(false);
+  });
+  it("keeps HOME", () => {
+    expect(shouldSanitize("HOME")).toBe(false);
+  });
+  it("keeps TERM", () => {
+    expect(shouldSanitize("TERM")).toBe(false);
+  });
+  it("keeps SHELL", () => {
+    expect(shouldSanitize("SHELL")).toBe(false);
+  });
 });
 
 // ── profile environment variables ──────────────────────────────────────────

--- a/tests/src/terminal/view.spec.ts
+++ b/tests/src/terminal/view.spec.ts
@@ -11,12 +11,12 @@
 import { describe, it, expect, vi } from "vitest";
 
 /*
- * Mock `src/import.js` — the BUNDLE map provides lazy `require()` loaders for
+ * Mock `src/imports.js` — the BUNDLE map provides lazy `require()` loaders for
  * xterm addon packages that are not built/available in the test environment.
  * Replacing the map entries with no-op factories prevents unhandled rejections
  * from `dynamicRequire`.
  */
-vi.mock("../../../src/import.js", () => {
+vi.mock("../../../src/imports.js", () => {
   const dummy = (): Record<string, unknown> => ({});
   const entries: Array<[string, () => Record<string, unknown>]> = [
     ["@xterm/addon-canvas", dummy],
@@ -175,7 +175,7 @@ describe("src/terminal/view.ts", () => {
       const result = view.getDisplayText();
       expect(mockI18n.t).toHaveBeenCalledWith(
         "components.terminal.display-name",
-        expect.objectContaining({ title: expect.any(String) }),
+        expect.objectContaining({ title: expect.any(String) as unknown }),
       );
       expect(result).toBe("components.terminal.display-name");
     });


### PR DESCRIPTION
## Problem

Main CI is red at the **Run tests** step for two stacked reasons:

1. `lodash-es` was removed from `package.json` in 934670cd as unused, but 10 source files and 2 test files still import it. tsc and esbuild resolve it through the vendor library's hoisted copy, but vitest does not: `Failed to resolve import "lodash-es"`.
2. Masked behind that: `view.spec.ts` mocks `src/import.js`, renamed to `src/imports.js` in 38203ff3. The stale mock lets the real module `require("@xterm/addon-ligatures")`, whose published `main` entry does not exist in 0.10.0, causing an unhandled rejection.

Because CI runs tests **before** build, the build step's `tsc` gate has not executed on main. Fixing only the test failures unmasks ~156 pre-existing type errors (verified on this PR's earlier CI run and reproduced locally with the CI toolchain).

## Fix

- Migrate all `lodash-es` imports to `es-toolkit` (already a dependency), matching main's direction (934670cd, a945e5d5).
- Fix the stale `vi.mock` path in `view.spec.ts`.
- Fix the type errors that `es-toolkit`'s stricter typings surface across `src/` and `tests/` so the build step passes end to end.

## Verification (local, CI-equivalent toolchain: TS 6.0.3, fresh install, vendor built per workflow)

- `tsc --noEmit`: 0 errors (main: 156+)
- `vitest`: 17 files, 243 tests pass, zero unhandled errors
- prettier and eslint clean