### PR TITLE
fix(terminal): survive denied process-group signal during Unix PTY teardown

### DIFF
--- a/.changeset/fix-unix-pty-teardown-permission-error.md
+++ b/.changeset/fix-unix-pty-teardown-permission-error.md
@@ -1,0 +1,5 @@
+---
+"obsidian-terminal": patch
+---
+
+Fix `Terminal exited: 1` and a Python `PermissionError` traceback when closing an integrated terminal pane on macOS (since 3.26.0). The terminal proxy now closes the pseudo-terminal first and stops as soon as no process in the shell's process group is left running. A shell that exits on hangup closes its pane in well under a second. The shell and any program it started in its process group that ignore the hangup are sent `SIGTERM` after one second, then `SIGKILL` after another second if still running. (TES-128; GH #162)

--- a/src/terminal/unix_pseudoterminal.py
+++ b/src/terminal/unix_pseudoterminal.py
@@ -7,9 +7,11 @@ separate FD to update terminal window size.
 
 from __future__ import annotations
 
+import os
 import sys
 from contextlib import suppress
 from os import (
+    close,
     execvp,
     read,
     waitpid,
@@ -83,7 +85,11 @@ def main() -> None:
 
 if sys.platform != "win32":
     from fcntl import ioctl  # ty: ignore[possibly-missing-import]
-    from os import getpgid, getppid, killpg  # ty: ignore[possibly-missing-import]
+    from os import (
+        WNOHANG,  # ty: ignore[possibly-missing-import]
+        getppid,
+        killpg,  # ty: ignore[possibly-missing-import]
+    )
     from pty import fork  # ty: ignore[possibly-missing-import]
     from signal import SIGHUP, SIGKILL  # ty: ignore[possibly-missing-import]
     from termios import TIOCSWINSZ  # ty: ignore[possibly-missing-import]
@@ -91,35 +97,85 @@ if sys.platform != "win32":
     """Selector timeout used to periodically check parent process liveness."""
     _SELECT_TIMEOUT_SECONDS = 0.5
 
-    """Signal grace timings for child process-group termination escalation."""
+    """Seconds to wait for the shell to exit after each signal."""
     _TERMINATION_SEQUENCE = (
         (SIGHUP, 1.0),
         (SIGTERM, 1.0),
-        (SIGKILL, 0.0),  # No grace period after SIGKILL since it's not catchable.
+        (SIGKILL, 2.0),
     )
 
-    def terminate_process_group(pid: int) -> None:
-        """Best-effort termination of the child process group for `pid`.
+    """Polling interval while waiting for the child to exit."""
+    _TERMINATION_POLL_SECONDS = 0.05
 
-        The child created via ``pty.fork()`` runs in its own session/process group,
-        so terminating the proxy process alone does not guarantee the shell tree
-        exits. This helper escalates from ``SIGHUP`` to ``SIGTERM`` and then
-        ``SIGKILL`` with short grace delays.
+    def _group_alive(pgid: int) -> bool:
+        """Return True while at least one live process remains in process group.
+
+        The process group is identified by `pgid`.
         """
-        try:
-            pgid = getpgid(pid)
-        except ProcessLookupError:
-            return
+        if os.path.isdir("/proc"):
+            for entry in os.listdir("/proc"):
+                if not entry.isdigit():
+                    continue
+                try:
+                    with open(f"/proc/{entry}/stat", encoding="utf-8") as stat_file:
+                        fields = stat_file.read().rsplit(")", 1)[1].split()
+                    if int(fields[2]) == pgid and fields[0] not in "ZX":
+                        return True
+                except (OSError, ValueError):
+                    continue
+            return False
 
-        for sig, wait_seconds in _TERMINATION_SEQUENCE:
-            try:
-                killpg(pgid, sig)
-            except ProcessLookupError:
-                return
-            # Give the process group a brief grace window between escalation
-            # steps to exit cleanly before sending a stronger signal.
-            if wait_seconds > 0:
-                sleep(wait_seconds)
+        try:
+            killpg(pgid, 0)
+            return True
+        except PermissionError:
+            # On macOS, a group whose remaining members have all exited but
+            # are not yet collected answers EPERM, so this means "no live
+            # member".
+            return False
+        except ProcessLookupError:
+            return False
+        except OSError:
+            return False
+
+    def terminate_shell(pid: int, pty_fd: int) -> int | None:
+        """Close the pseudo-terminal and stop the shell's process group.
+
+        Close the pseudo-terminal, send SIGHUP, SIGTERM, and SIGKILL to the
+        shell's process group, waiting after each until no live process remains
+        in the group. Then collect the shell and return its wait status, or
+        ``None`` if it remains running.
+        """
+        # Close the master first: the kernel hangs up the session and drops
+        # pending output, so an exiting shell cannot block on its final terminal
+        # write.
+        with suppress(OSError):
+            close(pty_fd)
+
+        group_quiet = False
+        for sig, grace in _TERMINATION_SEQUENCE:
+            # On macOS, killpg can raise PermissionError when the group's only
+            # member has exited; the next poll collects the child harmlessly.
+            with suppress(OSError):
+                killpg(pid, sig)
+            elapsed = 0.0
+            while elapsed < grace:
+                interval = min(_TERMINATION_POLL_SECONDS, grace - elapsed)
+                sleep(interval)
+                elapsed += interval
+                if not _group_alive(pid):
+                    group_quiet = True
+                    break
+            if group_quiet:
+                break
+
+        try:
+            waited, status = waitpid(pid, WNOHANG)
+        except ChildProcessError:
+            return 0
+        if waited == pid:
+            return status
+        return None
 
     class _SelectorHandler:
         """Base context-manager that registers a read-callback for an FD.
@@ -242,6 +298,7 @@ if sys.platform != "win32":
 
         old_sigint = signal(SIGINT, request_shutdown)
         old_sigterm = signal(SIGTERM, request_shutdown)
+        exit_code: int | None = None
         try:
             with (
                 DefaultSelector() as selector,
@@ -267,12 +324,26 @@ if sys.platform != "win32":
                 )
                 # If host side is gone (or we got SIGINT/SIGTERM), tear
                 # down the child session proactively to avoid orphans.
-                if pipe_pty.registered and (host_disconnected or shutdown_requested):
-                    terminate_process_group(pid)
+                # Exit 0 when the host asked for the shutdown and the shell has
+                # exited: the shell's signal status carries no information for
+                # the user, and "0" is in the plugin's default success exit
+                # codes (src/magic.ts), so no error notice.
+                # Exit 1 only when the shell is still running after the last wait.
+                if host_disconnected or shutdown_requested:
+                    if pipe_pty.registered:
+                        exit_code = 0 if terminate_shell(pid, pty_fd) is not None else 1
+                    else:
+                        # The shell already exited on its own; collect it and
+                        # report success because the host asked for shutdown.
+                        with suppress(ChildProcessError):
+                            waitpid(pid, 0)
+                        exit_code = 0
         finally:
             signal(SIGINT, old_sigint)
             signal(SIGTERM, old_sigterm)
 
+        if exit_code is not None:
+            exit(exit_code)
         exit(waitstatus_to_exitcode(waitpid(pid, 0)[1]))
 
 

--- a/tests/src/terminal/test_unix_pseudoterminal.py
+++ b/tests/src/terminal/test_unix_pseudoterminal.py
@@ -1,14 +1,20 @@
 """Regression tests for the Unix PTY proxy lifecycle.
 
 These tests validate host-disconnect behavior in
-``src/terminal/unix_pseudoterminal.py`` without spawning real PTYs.
+``src/terminal/unix_pseudoterminal.py`` with deterministic doubles and two real proxies.
 """
 
 from __future__ import annotations
 
 import os
+import select
+import shutil
+import signal
+import subprocess
 import sys
-from collections.abc import Callable
+import time
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager, suppress
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -20,9 +26,14 @@ from typing_extensions import Self
 __all__ = ()
 
 
+def _module_path() -> Path:
+    """Return the filesystem path to the Unix PTY proxy module."""
+    return Path(__file__).parents[3] / "src/terminal/unix_pseudoterminal.py"
+
+
 def _load_unix_pseudoterminal_module() -> ModuleType:
     """Load the Unix PTY proxy module from source for monkeypatching tests."""
-    path = Path(__file__).parents[3] / "src/terminal/unix_pseudoterminal.py"
+    path = _module_path()
     spec = spec_from_file_location("tests_unix_pseudoterminal_module", path)
     if spec is None or spec.loader is None:
         raise AssertionError(path)
@@ -43,15 +54,17 @@ def _load_unix_pseudoterminal_module() -> ModuleType:
 class _FakeSelector:
     """A deterministic selector test double.
 
-    The selector can emit at most one configured event and then returns empty
-    selections. If `select()` is called too many times, it raises an error to
-    catch loops that should have stopped.
+    The selector emits all configured events in one batch and then returns
+    empty selections. If `select()` is called too many times, it raises an
+    error to catch loops that should have stopped.
     """
 
-    def __init__(self, event_fd: int, max_select_calls: int = 3) -> None:
-        """Initialize with the file descriptor to emit and a loop guard."""
+    def __init__(
+        self, event_fd: int | Sequence[int], max_select_calls: int = 3
+    ) -> None:
+        """Initialize with one or more file descriptors to emit."""
         self._callbacks: dict[int, Callable[[], None]] = {}
-        self._event_fd = event_fd
+        self._event_fds = (event_fd,) if isinstance(event_fd, int) else tuple(event_fd)
         self._emitted = False
         self._select_calls = 0
         self._max_select_calls = max_select_calls
@@ -73,7 +86,7 @@ class _FakeSelector:
         self._callbacks.pop(fd, None)
 
     def select(self, _timeout: float | None = None) -> list[tuple[object, int]]:
-        """Return one synthetic event and then idle forever.
+        """Return one synthetic batch and then idle forever.
 
         A guard raises when too many `select()` calls occur, which catches
         loops that fail to stop after host disconnect.
@@ -82,13 +95,46 @@ class _FakeSelector:
         if self._select_calls > self._max_select_calls:
             raise RuntimeError("select loop did not terminate")
 
-        if not self._emitted and self._event_fd in self._callbacks:
-            self._emitted = True
-            callback = self._callbacks[self._event_fd]
-            if callback is None:
-                raise AssertionError(self._event_fd)
-            return [(SimpleNamespace(data=callback), 1)]
+        if not self._emitted:
+            events: list[tuple[object, int]] = [
+                (SimpleNamespace(data=self._callbacks[fd]), 1)
+                for fd in self._event_fds
+                if fd in self._callbacks
+            ]
+            if events:
+                self._emitted = True
+                return events
         return []
+
+
+def _patch_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+    module: ModuleType,
+    *,
+    fork_result: tuple[int, int],
+    event_fd: int | Sequence[int],
+    killpg: Callable[[int, int], None],
+    waitpid: Callable[[int, int], tuple[int, int]],
+    close: Callable[[int], None] | None = None,
+    sleep: Callable[[float], None] | None = None,
+    group_alive: Callable[[int], bool] | None = None,
+) -> None:
+    """Apply common deterministic patches for proxy shutdown unit tests."""
+    monkeypatch.setattr(module, "fork", lambda: fork_result)
+    monkeypatch.setattr(module, "DefaultSelector", lambda: _FakeSelector(event_fd))
+    monkeypatch.setattr(module, "getppid", lambda: 4242, raising=False)
+    monkeypatch.setattr(module, "read", lambda *_: b"")
+    monkeypatch.setattr(module, "killpg", killpg, raising=False)
+    monkeypatch.setattr(module, "waitpid", waitpid)
+    monkeypatch.setattr(module, "close", close or (lambda _fd: None))
+    monkeypatch.setattr(module, "sleep", sleep or (lambda _s: None), raising=False)
+    monkeypatch.setattr(
+        module,
+        "_group_alive",
+        group_alive or (lambda _pgid: False),
+        raising=False,
+    )
+    monkeypatch.setattr(module, "waitstatus_to_exitcode", lambda status: status)
 
 
 def test_main_stops_on_stdin_eof_and_terminates_child_group(
@@ -112,13 +158,17 @@ def test_main_stops_on_stdin_eof_and_terminates_child_group(
         """Record each signal used to terminate the child process group."""
         signal_calls.append(signal)
 
+    def fake_close(_fd: int) -> None:
+        """Ignore PTY closure after the host disconnects."""
+
     monkeypatch.setattr(module, "fork", lambda: (1234, 99))
     monkeypatch.setattr(module, "DefaultSelector", lambda: _FakeSelector(module._STDIN))
     monkeypatch.setattr(module, "exit", fake_exit)
-    monkeypatch.setattr(module, "getpgid", lambda _pid: 1234, raising=False)
     monkeypatch.setattr(module, "getppid", lambda: 4242, raising=False)
     monkeypatch.setattr(module, "killpg", fake_killpg, raising=False)
+    monkeypatch.setattr(module, "_group_alive", lambda _pgid: False, raising=False)
     monkeypatch.setattr(module, "read", fake_read)
+    monkeypatch.setattr(module, "close", fake_close)
     monkeypatch.setattr(module, "sleep", lambda _seconds: None, raising=False)
     monkeypatch.setattr(module, "waitpid", lambda pid, _flags: (pid, 0))
     monkeypatch.setattr(module, "waitstatus_to_exitcode", lambda status: status)
@@ -152,13 +202,17 @@ def test_main_does_not_terminate_group_when_pty_exits_first(
         """Record each signal if the proxy attempts group termination."""
         signal_calls.append(signal)
 
+    def fake_close(_fd: int) -> None:
+        """Ignore PTY closure if the PTY side closes first."""
+
     monkeypatch.setattr(module, "fork", lambda: (55, 77))
     monkeypatch.setattr(module, "DefaultSelector", lambda: _FakeSelector(77))
     monkeypatch.setattr(module, "exit", fake_exit)
-    monkeypatch.setattr(module, "getpgid", lambda _pid: 55, raising=False)
     monkeypatch.setattr(module, "getppid", lambda: 4242, raising=False)
     monkeypatch.setattr(module, "killpg", fake_killpg, raising=False)
+    monkeypatch.setattr(module, "_group_alive", lambda _pgid: False, raising=False)
     monkeypatch.setattr(module, "read", fake_read)
+    monkeypatch.setattr(module, "close", fake_close)
     monkeypatch.setattr(module, "sleep", lambda _seconds: None, raising=False)
     monkeypatch.setattr(module, "waitpid", lambda pid, _flags: (pid, 0))
     monkeypatch.setattr(module, "waitstatus_to_exitcode", lambda status: status)
@@ -168,3 +222,376 @@ def test_main_does_not_terminate_group_when_pty_exits_first(
 
     assert raised.value.code == 0
     assert signal_calls == []
+
+
+def test_teardown_stops_after_child_exits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stop signaling when the process group is quiet after the first signal."""
+    module = _load_unix_pseudoterminal_module()
+    signal_calls: list[int] = []
+    events: list[str] = []
+
+    def fake_killpg(_pgid: int, signal: int) -> None:
+        """Record each signal used to terminate the child process group."""
+        signal_calls.append(signal)
+        events.append(f"killpg:{signal}")
+
+    def fake_close(fd: int) -> None:
+        """Record PTY closure before the first termination signal."""
+        assert fd == 99
+        events.append("close")
+
+    def fake_waitpid(pid: int, flags: int) -> tuple[int, int]:
+        """Report immediate signal-encoded exit and reject blocking waits."""
+        if flags == 0:
+            raise AssertionError(
+                "blocking waitpid must not run after the shell was collected"
+            )
+        events.append("waitpid")
+        return pid, 1
+
+    _patch_proxy(
+        monkeypatch,
+        module,
+        fork_result=(1234, 99),
+        event_fd=module._STDIN,
+        killpg=fake_killpg,
+        waitpid=fake_waitpid,
+        close=fake_close,
+        group_alive=lambda _pgid: False,
+    )
+    monkeypatch.setattr(
+        module, "waitstatus_to_exitcode", lambda status: -1 if status == 1 else status
+    )
+
+    with pytest.raises(SystemExit) as raised:
+        module.main()
+
+    assert raised.value.code == 0
+    assert signal_calls == [module.SIGHUP]
+    assert events == ["close", f"killpg:{module.SIGHUP}", "waitpid"]
+    assert events.index("close") < events.index(f"killpg:{module.SIGHUP}")
+
+
+def test_shutdown_request_with_pty_eof_exits_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Report success when host shutdown and PTY EOF arrive in one batch."""
+    module = _load_unix_pseudoterminal_module()
+    signal_calls: list[int] = []
+
+    def fake_killpg(_pgid: int, signal_number: int) -> None:
+        """Record any unexpected process-group termination attempt."""
+        signal_calls.append(signal_number)
+
+    def fake_waitpid(pid: int, _flags: int) -> tuple[int, int]:
+        """Return a signal-encoded status for polling and blocking waits."""
+        return pid, 1
+
+    _patch_proxy(
+        monkeypatch,
+        module,
+        fork_result=(1234, 99),
+        event_fd=(module._STDIN, 99),
+        killpg=fake_killpg,
+        waitpid=fake_waitpid,
+    )
+    monkeypatch.setattr(
+        module, "waitstatus_to_exitcode", lambda status: -1 if status == 1 else status
+    )
+
+    with pytest.raises(SystemExit) as raised:
+        module.main()
+
+    assert raised.value.code == 0
+    assert signal_calls == []
+
+
+def test_teardown_survives_killpg_permission_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Continue polling when a process-group signal raises PermissionError."""
+    module = _load_unix_pseudoterminal_module()
+    signal_calls: list[int] = []
+    term_attempted = False
+
+    def fake_killpg(_pgid: int, _signal: int) -> None:
+        """Allow SIGHUP, then deny SIGTERM after recording the attempt."""
+        nonlocal term_attempted
+        signal_calls.append(_signal)
+        if _signal == module.SIGTERM:
+            term_attempted = True
+            raise PermissionError
+
+    def fake_waitpid(pid: int, flags: int) -> tuple[int, int]:
+        """Report the collected shell status after the group becomes quiet."""
+        if flags == 0:
+            raise AssertionError(
+                "blocking waitpid must not run after the shell was collected"
+            )
+        return pid, 0
+
+    def fake_group_alive(_pgid: int) -> bool:
+        """Keep the group alive through SIGHUP, then report it as quiet."""
+        return not term_attempted
+
+    _patch_proxy(
+        monkeypatch,
+        module,
+        fork_result=(1234, 99),
+        event_fd=module._STDIN,
+        killpg=fake_killpg,
+        waitpid=fake_waitpid,
+        group_alive=fake_group_alive,
+    )
+
+    with pytest.raises(SystemExit) as raised:
+        module.main()
+
+    assert raised.value.code == 0
+    assert signal_calls == [module.SIGHUP, module.SIGTERM]
+
+
+def test_teardown_bounded_when_child_unsignalable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exit with failure after the bounded wait when no signal can be delivered."""
+    module = _load_unix_pseudoterminal_module()
+    slept: list[float] = []
+    close_calls: list[int] = []
+
+    def fake_killpg(_pgid: int, _signal: int) -> None:
+        """Reject every group signal to exercise the unsignalable path."""
+        raise PermissionError
+
+    def fake_sleep(seconds: float) -> None:
+        """Record bounded polling intervals without delaying the test."""
+        slept.append(seconds)
+
+    def fake_waitpid(_pid: int, flags: int) -> tuple[int, int]:
+        """Report that the child remains running and reject blocking waits."""
+        if flags == 0:
+            raise AssertionError(
+                "blocking waitpid should not run after failed teardown"
+            )
+        return 0, 0
+
+    def fake_close(fd: int) -> None:
+        """Record closure of the PTY descriptor before failure exit."""
+        close_calls.append(fd)
+
+    _patch_proxy(
+        monkeypatch,
+        module,
+        fork_result=(1234, 99),
+        event_fd=module._STDIN,
+        killpg=fake_killpg,
+        waitpid=fake_waitpid,
+        close=fake_close,
+        sleep=fake_sleep,
+        group_alive=lambda _pgid: True,
+    )
+
+    with pytest.raises(SystemExit) as raised:
+        module.main()
+
+    assert raised.value.code == 1
+    assert 3.9 <= sum(slept) <= 4.0 + 0.01
+    assert close_calls == [99]
+
+
+def test_teardown_ends_group_members_after_shell_exits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Continue signaling after the shell exits while a group member remains."""
+    module = _load_unix_pseudoterminal_module()
+    signal_calls: list[int] = []
+    slept: list[float] = []
+    term_signal_elapsed: list[float] = []
+    term_sent = False
+
+    def fake_killpg(_pgid: int, signal_number: int) -> None:
+        """Record group signals and the elapsed SIGHUP grace period."""
+        nonlocal term_sent
+        signal_calls.append(signal_number)
+        if signal_number == module.SIGTERM:
+            term_signal_elapsed.append(sum(slept))
+            term_sent = True
+
+    def fake_sleep(seconds: float) -> None:
+        """Record polling intervals without delaying the test."""
+        slept.append(seconds)
+
+    def fake_group_alive(_pgid: int) -> bool:
+        """Keep a remaining group member alive until SIGTERM is sent."""
+        return not term_sent
+
+    def fake_waitpid(pid: int, flags: int) -> tuple[int, int]:
+        """Return the collected shell status without allowing a blocking wait."""
+        if flags == 0:
+            raise AssertionError("blocking waitpid should not run after teardown")
+        return pid, 0
+
+    _patch_proxy(
+        monkeypatch,
+        module,
+        fork_result=(1234, 99),
+        event_fd=module._STDIN,
+        killpg=fake_killpg,
+        waitpid=fake_waitpid,
+        sleep=fake_sleep,
+        group_alive=fake_group_alive,
+    )
+
+    with pytest.raises(SystemExit) as raised:
+        module.main()
+
+    assert raised.value.code == 0
+    assert signal_calls == [module.SIGHUP, module.SIGTERM]
+    assert 0.95 <= term_signal_elapsed[0] <= 1.06
+
+
+@contextmanager
+def _spawn_proxy(
+    argv: list[str], marker: str
+) -> Iterator[tuple[subprocess.Popen[bytes], int]]:
+    """Spawn a real proxy and clean up its process and command pipe."""
+    cmd_read, cmd_write = os.pipe()
+    process: subprocess.Popen[bytes] | None = None
+
+    def preexec() -> None:
+        """Duplicate the resize pipe into the proxy's fixed command descriptor."""
+        os.dup2(cmd_read, 3)
+
+    try:
+        process = subprocess.Popen(
+            [sys.executable, str(_module_path()), *argv],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            preexec_fn=preexec,  # noqa: PLW1509
+            pass_fds=(cmd_read, 3),
+            close_fds=True,
+        )
+        os.close(cmd_read)
+        cmd_read = -1
+        process_stdout = process.stdout
+        if process_stdout is None:
+            raise AssertionError("proxy stdout pipe is unavailable")
+        output = b""
+        deadline = time.monotonic() + 5.0
+        while not any(b"READY" in line for line in output.splitlines()):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("proxy did not become ready")
+            ready_fds, _, _ = select.select([process_stdout], [], [], remaining)
+            if not ready_fds:
+                raise TimeoutError("proxy did not become ready")
+            data = os.read(process_stdout.fileno(), 1024)
+            if not data:
+                raise AssertionError("proxy exited before becoming ready")
+            output += data
+        yield process, cmd_write
+    finally:
+        if cmd_read >= 0:
+            with suppress(OSError):
+                os.close(cmd_read)
+        with suppress(OSError):
+            os.close(cmd_write)
+        if process is not None and process.poll() is None:
+            process.kill()
+            process.wait()
+        survivors = subprocess.run(
+            ["pgrep", "-f", marker],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        for line in survivors.stdout.splitlines():
+            with suppress(ValueError, ProcessLookupError):
+                os.kill(int(line), 9)
+        assert survivors.returncode != 0 or not survivors.stdout.strip()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only proxy")
+def test_real_proxy_exits_cleanly_on_host_disconnect() -> None:
+    """Exit cleanly without a traceback when the host closes both input pipes."""
+    marker = f"4000.{time.monotonic_ns() % 1_000_000:06d}"
+    with _spawn_proxy(
+        ["/bin/sh", "-c", f"echo READY; exec sleep {marker}"], marker
+    ) as (
+        process,
+        cmd_write,
+    ):
+        start = time.monotonic()
+        os.close(cmd_write)
+        _, stderr_data = process.communicate(timeout=5)
+        elapsed = time.monotonic() - start
+
+        assert process.returncode == 0
+        assert stderr_data == b""
+        assert elapsed < 3.0
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only proxy")
+@pytest.mark.skipif(shutil.which("zsh") is None, reason="zsh is unavailable")
+def test_real_proxy_exits_promptly() -> None:
+    """Exit an interactive shell promptly after both host pipes close."""
+    zsh = shutil.which("zsh")
+    assert zsh is not None
+    marker = f"4000.{time.monotonic_ns() % 1_000_000:06d}"
+    with _spawn_proxy(
+        [zsh, "-l", "-i", "-c", f"echo READY; sleep {marker}; exec zsh -l"],
+        marker,
+    ) as (process, cmd_write):
+        os.write(cmd_write, b"24x80\n")
+        start = time.monotonic()
+        if process.stdin is None:
+            raise AssertionError("proxy stdin pipe is unavailable")
+        process.stdin.close()
+        process.stdin = None
+        os.close(cmd_write)
+        _, stderr_data = process.communicate(timeout=5)
+        elapsed = time.monotonic() - start
+
+        assert process.returncode == 0
+        assert stderr_data == b""
+        assert elapsed < 3.0
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only proxy")
+def test_real_proxy_exits_zero_on_sigterm_with_stdin_open() -> None:
+    """Exit cleanly when SIGTERM arrives while host pipes remain open."""
+    marker = f"4000.{time.monotonic_ns() % 1_000_000:06d}"
+    with _spawn_proxy(
+        ["/bin/sh", "-c", f"echo READY; exec sleep {marker}"], marker
+    ) as (process, _cmd_write):
+        process.send_signal(signal.SIGTERM)
+        _, stderr_data = process.communicate(timeout=5)
+
+        assert process.returncode == 0
+        assert stderr_data == b""
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only proxy")
+def test_real_proxy_ends_nohup_child() -> None:
+    """End a nohup child when the host disconnects from the proxy."""
+    marker = f"9500.{time.monotonic_ns() % 1_000_000:06d}"
+    with _spawn_proxy(
+        [
+            "/bin/sh",
+            "-c",
+            f"echo READY; nohup sleep {marker} >/dev/null 2>&1 & wait",
+        ],
+        marker,
+    ) as (process, cmd_write):
+        time.sleep(0.1)
+        start = time.monotonic()
+        os.close(cmd_write)
+        _, stderr_data = process.communicate(timeout=5)
+        elapsed = time.monotonic() - start
+
+        assert process.returncode == 0
+        assert stderr_data == b""
+        assert 0.9 <= elapsed <= 3.0


### PR DESCRIPTION
## Summary

Since 3.26.0, closing an integrated terminal on macOS shows `Terminal exited: 1` and logs a Python traceback. The cause is the shutdown step added in `28ef330b` for #162. This PR makes that step safe and fast: the proxy closes the pseudo-terminal first, stops as soon as no process in the shell's process group is left running, and never raises. A shell that exits on hangup closes its pane in about 50 ms. Programs the shell started in its process group are ended too.

Fixes #185. Related: #162, whose fix in `28ef330b` introduced this regression.

## Root cause

When the plugin disconnects, the proxy sends `SIGHUP` to the shell's process group, waits 1 s, then sends `SIGTERM`. The shell exits on `SIGHUP` within milliseconds, but the proxy does not collect its exit status until the end, so the shell stays in the process table as a zombie. On macOS, `killpg` on a process group that holds only a zombie fails with `EPERM`. Only `ProcessLookupError` was caught, so the proxy crashed with exit code 1.

A second problem was hidden behind the crash. The proxy stops reading the pseudo-terminal during shutdown. An interactive shell writes to the terminal while it exits, that write blocks, and the shell cannot finish. With the crash removed but nothing else changed, the proxy waited the full sequence and still exited 1.

## Changes

All in `src/terminal/unix_pseudoterminal.py` and its tests. The shutdown function and its process-group check are about 70 lines together.

- Close the pseudo-terminal before the first signal. The kernel then hangs up the session and drops pending output, so an exiting shell cannot block on its final write.
- Send `SIGHUP`, `SIGTERM`, `SIGKILL` to the shell's process group in turn, with waits of 1 s, 1 s, and 2 s. Every 50 ms, check whether any live process remains in the group. Stop as soon as none does, then collect the shell's exit status.
- Keep the shell uncollected while signals are sent, so its process-group id cannot be reused by an unrelated process. On macOS the check is `killpg(pgid, 0)`: it fails with `EPERM` once only exited, uncollected processes remain. On Linux, where that call also counts exited processes, the check reads `/proc`.
- Ignore `OSError` from `killpg`. The shell is a session leader, so its process-group id is its own pid and needs no lookup.
- Exit code: when the plugin started the shutdown and the shell has exited, exit 0, even if the shell exited on its own in the same instant. `"0"` is in the plugin's default success exit codes, so no error notice appears. Exit 1 only if the shell is still running 2 s after `SIGKILL`. When the shell exits on its own without a shutdown request, report its exit code as before.

Why the group check matters: a program the shell started with `nohup` ignores the hangup and outlives the shell. Before this change the proxy stopped as soon as the shell had exited, so that program kept running (real example below). With the group check it receives `SIGTERM` after the 1 s hangup window.

## Tests

- `uv run --locked pytest tests/src/terminal/test_unix_pseudoterminal.py`: 11 passed. The 2 existing tests are unchanged. 5 unit tests cover stop when the group is quiet, `PermissionError` on the second signal, the bounded wait, a shutdown request that arrives as the shell exits, and ending group members after the shell exits. 4 tests run the real proxy as a subprocess: a plain child, the interactive `zsh` profile, `SIGTERM` to the proxy while the plugin is still connected, and a `nohup` child that must be ended. The child prints a ready marker before the test disconnects. The plain, `zsh`, and `nohup` tests fail on `main` and pass here.
- `bun run check`: clean.
- Real-pipe runs against the built source:

| Child process | Result |
| --- | --- |
| `/bin/sh -c 'exec sleep N'` | exit 0 in 0.06 s |
| `/bin/sh -c "trap '' HUP; sleep N; exit"` (the #162 case) | exit 0 in 1.2 s, child ended by `SIGTERM` |
| `/bin/zsh -l -i -c "sleep N; exec zsh -l"` (real profile) | exit 0 in 0.06 s, child ended |
| `/bin/sh -c "nohup sleep N & wait"` | exit 0 in 1.1 s, `nohup` child ended by `SIGTERM` |

- Live Obsidian 1.13.7 on macOS: 3.26.0 shows the traceback and the `Terminal exited: 1` notice on every close, and the shell lingers about 1 s before the crash. This branch: no traceback, the normal `Terminal exited: 0` notice, shell and proxy gone well under a second after the close, no leftover process.

## Evidence (Obsidian 1.13.7, macOS)

3.26.0, two seconds after closing the pane. No leftover process, but the proxy crashed and the `Terminal exited: 1` notice is visible top-right.

![3.26.0 after closing the pane](https://github.com/user-attachments/assets/c743c866-d0e0-43bb-b879-d5eb92f1dada)

This branch, after closing the pane. No traceback, no error notice, no leftover process.

![Fixed build after closing the pane: no error notice, no leftover process](https://github.com/user-attachments/assets/54032bba-3bf1-47aa-9ac0-4ee829aaca10)

Real example for the process-group check. Profile: `/bin/sh -c "nohup python3 -m http.server 8766 & wait"`, a wrapper shell that starts a background web server. Before this change, three seconds after closing the pane the shell is gone but the server is still running with parent pid 1 and still listening, while the notice says `Terminal exited: 0`:

![Before: the web server survives the pane close](https://github.com/user-attachments/assets/524bd795-9c1f-4ecd-9cc9-851f8719d07d)

With this change, the server is ended by `SIGTERM` after the 1 s hangup window and the port is free:

![After: the web server is gone after the pane close](https://github.com/user-attachments/assets/81aba8d4-f445-4410-89f1-80126d73b4a0)
